### PR TITLE
Fix system mount point mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ chroot-distro unbackup <distro>
 + restore distro
   + By default restores as is, use `-d` or `--default` to reset to default settings (note: only those set during install)
   + If path given, then backup restored from that path
-  + If using old format backups you may need to use `--force` to restore the backup but please be aware that you should review the backup before restoring said backup as there may be more files than there should be, or there could be uninteded side effects (for example system mounts shadowing restored files)
+  + If using old format backups you may need to use `--force` to restore the backup but please be aware that you should review the backup before restoring said backup as there could be uninteded side effects (for example system mounts shadowing restored files or internal storage running out)
 ```
 chroot-distro restore [-d|--default] [--force] <distro> [<path>]
 ```

--- a/README.md
+++ b/README.md
@@ -16,11 +16,17 @@ Reasonably new Busybox-ndk magisk module version installed (1.36.1 is known to w
 + /proc
 + /dev/pts
 + /sdcard 
-+ /system
++ /system *(NOTE: not used by default)*
 + /storage
-+ /data
++ /data *(NOTE: not used by default)*
 
 ## Using
+
+### Root usage
+
+Be aware that as the chroot-distro needs to be running as a root to function there is a possibility that some corner case may have been missed where it is possible to accidentally removed more files than intended. The developers strive to ensure that this will not happen but before using the software you should backup your files/firmware just in case. Please also note that this is not specific to only this software but should be used as a general caution when ever using a rooted device.
+
+As they say: *With great power comes great responsibility.*
 
 ### Available commands
 
@@ -47,14 +53,14 @@ chroot-distro delete <distro>
 ```
 
 + install distro
-  + By default does not mount `/data` folder, use -d or --data to mount it
+  + By default does not mount `/data` or `/system` folder, use `-a` or `--android` to mount it
 ```
-chroot-distro install [-d|--data] <distro>
+chroot-distro install [-a|--android] <distro>
 ```
 + reinstall distro
-  + By default does not mount `/data` folder, use -d or --data to mount it
+  + By default does not mount `/data` or `/system` folder, use `-a` or `--android` to mount it
 ```
-chroot-distro reinstall [-d|--data] <distro>
+chroot-distro reinstall [-a|--android] <distro>
 ```
 + uninstall distro
 ```
@@ -71,10 +77,11 @@ chroot-distro backup <distro> [<path>]
 chroot-distro unbackup <distro>
 ```
 + restore distro
-  + By default restores as is, use -d or --default to reset to default settings (note: only those set during install)
+  + By default restores as is, use `-d` or `--default` to reset to default settings (note: only those set during install)
   + If path given, then backup restored from that path
+  + If using old format backups you may need to use `--force` to restore the backup but please be aware that you should review the backup before restoring said backup as there may be more files than there should be, or there could be uninteded side effects (for example system mounts shadowing restored files)
 ```
-chroot-distro restore [-d|--default] <distro> [<path>]
+chroot-distro restore [-d|--default] [--force] <distro> [<path>]
 ```
 
 + unmount system mount points
@@ -83,7 +90,7 @@ chroot-distro unmount <distro>
 ```
 
 + run command
-  + By default runs command from under `/bin`, use --as-is to run any command but then path needs to be supplied
+  + By default runs command from under `/bin`, use `--as-is` to run any command but then path needs to be supplied
   + If command is quoted then can pass parameters to command, for example `"ping 127.0.0.1"`
 ```
 chroot-distro command <distro> [--as-is] <command>
@@ -122,9 +129,12 @@ Note: right side is used as distro identifier, and it needs to be lowercase for 
 + Ubuntu : ubuntu
 + Void Linux : void
 
-### best features :
+### Supported environments
+
 you can use chroot-distro on any terminal
 like mt manager , termux , twrp , Android terminal emulator...
+
+### Sample screenshots
 
 ![Debian console](screenshot/debian.png)
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ Note: right side is used as distro identifier, and it needs to be lowercase for 
 
 ### Supported environments
 
-you can use chroot-distro on any terminal
-like mt manager , termux , twrp , Android terminal emulator...
+You can use chroot-distro on any terminal, for example mt manager, termux, twrp or Android terminal emulator...
 
 ### Sample screenshots
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -624,14 +624,16 @@ chroot_distro_mount_system_point() {
 
 chroot_distro_mount_system_points() {
     distro_path="$1"
-    use_data="$2"
+    use_android="$2"
     chroot_distro_mount_system_point /dev "$distro_path/dev"
     chroot_distro_mount_system_point /sys "$distro_path/sys"
     chroot_distro_mount_system_point /proc "$distro_path/proc"
     chroot_distro_mount_system_point /dev/pts "$distro_path/dev/pts"
     chroot_distro_mount_system_point /sdcard "$distro_path/sdcard"
-    chroot_distro_mount_system_point /system "$distro_path/system"
-    if [ "yes" = "$use_data" ] || [ -d "$distro_path/data" ]; then
+    if [ "yes" = "$use_android" ] || [ -d "$distro_path/system" ]; then
+        chroot_distro_mount_system_point /system "$distro_path/system"
+    fi
+    if [ "yes" = "$use_android" ] || [ -d "$distro_path/data" ]; then
         chroot_distro_mount_system_point /data "$distro_path/data"
     fi
     for file in "/storage"/*; do
@@ -742,7 +744,7 @@ chroot_distro_check_if_system_points_mounted() {
 
 chroot_distro_install() {
     distro=$1
-    use_data=$2
+    use_android=$2
     supported="alpine archlinux artix debian deepin fedora manjaro openkylin opensuse pardus ubuntu void kali parrot backbox centos centos_stream"
     if ! chroot_distro_check_if_supported "$supported" "$distro"; then
         echo "unavailable distro $distro"
@@ -777,7 +779,7 @@ chroot_distro_install() {
         mv "$chroot_distro_path/$rootdir" "$distro_path"
     fi
 
-    chroot_distro_mount_system_points "$distro_path" "$use_data"
+    chroot_distro_mount_system_points "$distro_path" "$use_android"
 
     echo "nameserver 8.8.8.8" > "$distro_path"/etc/resolv.conf
     echo "127.0.0.1 localhost" > "$distro_path"/etc/hosts
@@ -1082,13 +1084,13 @@ elif [ "$command" = "delete" ]; then
     fi
     chroot_distro_delete "$1"
 elif [ "$command" = "install" ]; then
-    PARSED=$(getopt --options=d --longoptions=data --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
-    data=no
+    android=no
     while true; do
         case "$1" in
-            -d|--data)
-                data=yes
+            -a|--android)
+                android=yes
                 shift
                 ;;
             --)
@@ -1106,7 +1108,7 @@ elif [ "$command" = "install" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
-    chroot_distro_install "$1" "$data"
+    chroot_distro_install "$1" "$android"
 elif [ "$command" = "uninstall" ]; then
     PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     if [ $# -eq 0 ]; then
@@ -1116,13 +1118,13 @@ elif [ "$command" = "uninstall" ]; then
     fi
     chroot_distro_uninstall "$1"
 elif [ "$command" = "reinstall" ]; then
-    PARSED=$(getopt --options=d --longoptions=data --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
-    data=no
+    android=no
     while true; do
         case "$1" in
-            -d|--data)
-                data=yes
+            -a|--android)
+                android=yes
                 shift
                 ;;
             --)
@@ -1141,7 +1143,7 @@ elif [ "$command" = "reinstall" ]; then
         chroot_distro_user_check_parameters
     fi
     chroot_distro_uninstall "$1"
-    chroot_distro_install "$1" "$data"
+    chroot_distro_install "$1" "$android"
 elif [ "$command" = "backup" ]; then
     PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     if [ $# -eq 0 ]; then
@@ -1159,7 +1161,7 @@ elif [ "$command" = "unbackup" ]; then
     fi
     chroot_distro_unbackup "$1"
 elif [ "$command" = "restore" ]; then
-    OPTS=df LONGOPTS=default,force
+    OPTS=d LONGOPTS=default,force
     PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     restore_defaults=no
@@ -1170,7 +1172,7 @@ elif [ "$command" = "restore" ]; then
                 restore_defaults=yes
                 shift
                 ;;
-            -f|--force)
+            --force)
                 force=yes
                 shift
                 ;;

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -784,7 +784,10 @@ chroot_distro_install() {
     chroot "$distro_path" /sbin/usermod -G 3003 -a root 2>/dev/null
     chroot "$distro_path" /bin/ln -sf /usr/share/zoneinfo/Asia/Taipei /etc/localtime 2>/dev/null
     chroot "$distro_path" /sbin/locale-gen en_US.UTF-8 2>/dev/null
-    chroot "$distro_path" /bin/su - root
+    # shellcheck disable=SC1007
+    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
+    # to prevent leaking host stuff to chroot to ensure consistent environment
+    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
 }
 
 chroot_distro_uninstall() {
@@ -972,7 +975,10 @@ chroot_distro_restore() {
         chroot "$distro_path" /bin/ln -sf /usr/share/zoneinfo/Asia/Taipei /etc/localtime 2>/dev/null
         chroot "$distro_path" /sbin/locale-gen en_US.UTF-8 2>/dev/null
     fi
-    chroot "$distro_path" /bin/su - root
+    # shellcheck disable=SC1007
+    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
+    # to prevent leaking host stuff to chroot to ensure consistent environment
+    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
 }
 
 chroot_distro_unmount() {

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -804,6 +804,15 @@ chroot_distro_uninstall() {
     distro_path="$chroot_distro_path/$1"
     if [ -d "$distro_path" ]; then
         chroot_distro_unmount_system_points "$distro_path" no
+        mount_count=$(mount | grep -c "$distro_path")
+        if [ "0" != "$mount_count" ]; then
+            # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
+            echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
+            exit 1
+        fi
+
+        # when reaching this point it is assumed that uninstalling the distro is ok, no irreversible changes to distro before this line
+
         # ensure that there is no symbolic links before nuking the rootfs, symbolic links may point outside of rootfs when outside of the chroot
         find "$distro_path" -type l -exec unlink {} \;
         rm -rf "$distro_path"
@@ -835,6 +844,14 @@ chroot_distro_backup() {
     if chroot_distro_check_if_system_points_mounted "$distro_path"; then
         echo "distro is potentially running - if needed shutdown the distro, and unmount system mount points ($script unmount $1) before proceeding"
         exit
+    fi
+
+    # mounted volumes should be backed up outside of this script as it may not work as intended
+    # (same reasons as system mount points)
+    mount_count=$(mount | grep -c "$distro_path")
+    if [ "0" != "$mount_count" ]; then
+        echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
+        exit 1
     fi
 
     if [ "$2" = "" ]; then

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -612,6 +612,10 @@ chroot_distro_mount_system_point() {
             exit 1
         fi
     fi
+    if mountpoint -q "$mount_point"; then
+        # nothing to do, already mounted
+        return
+    fi
     if ! mount --bind "$path_to_mount" "$mount_point"; then
         echo "could not mount $path_to_mount to $mount_point"
         exit 1

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1000,9 +1000,10 @@ chroot_distro_command() {
         command="/bin/$2"
     fi
 
-    # shellcheck disable=SC2086
-    # intentionally left out quotes to make it possible to provide arguments
-    chroot "$distro_path/" $command
+    # shellcheck disable=SC1007
+    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
+    # to prevent leaking host stuff to chroot to ensure consistent environment
+    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root -c "$command"
 }
 
 chroot_distro_login() {
@@ -1020,7 +1021,10 @@ chroot_distro_login() {
 
     chroot_distro_mount_system_points "$distro_path" no
 
-    chroot "$distro_path/" /bin/su - root
+    # shellcheck disable=SC1007
+    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
+    # to prevent leaking host stuff to chroot to ensure consistent environment
+    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
 }
 
 chroot_distro_invalid_parameters() {

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -6,6 +6,7 @@
 # for the full terms.
 
 chroot_distro_path="/data/local/chroot-distro"
+script=$(basename "$0")
 
 if [ "$(whoami)" != "root" ]; then
     echo "Root access required."
@@ -50,35 +51,35 @@ fi
 
 
 chroot_distro_help() {
-    echo "$0 : install linux distributions
+    echo "$script : install linux distributions
 
 usage :
 
-$0 help - for more information
-$0 list - list of available linux distributions
+$script help - for more information
+$script list - list of available linux distributions
 
-$0 download <distro> - download rootfs
-$0 redownload <distro> - redownload rootfs
-$0 delete <distro> - delete rootfs
+$script download <distro> - download rootfs
+$script redownload <distro> - redownload rootfs
+$script delete <distro> - delete rootfs
 
-$0 install <distro> [-d|--data] - install distro
+$script install <distro> [-d|--data] - install distro
     '-d|--data' Installs also /data folder, by default not installed
-$0 reinstall <distro> [-d|--data] - reinstall distro
+$script reinstall <distro> [-d|--data] - reinstall distro
     '-d|--data' Installs also /data folder, by default not installed
-$0 uninstall <distro> - uninstall distro
+$script uninstall <distro> - uninstall distro
 
-$0 unmount <distro> - unmount system mount points from distro
+$script unmount <distro> - unmount system mount points from distro
 
-$0 backup <distro> [<path>] - backup distro
+$script backup <distro> [<path>] - backup distro
     <path>          Custom path for backup location
-$0 restore <distro> [-d|--default] [<path>] - restore distro
+$script restore <distro> [-d|--default] [<path>] - restore distro
     <path>          Custom path for backup location
     '-d|--default'  restore default settings (note: only those set during install)
-$0 unbackup <distro> - delete backup from default location
+$script unbackup <distro> - delete backup from default location
 
-$0 command <distro> [--as-is] <command> - run command
+$script command <distro> [--as-is] <command> - run command
     '--as-is' full path needs to be specified for the command
-$0 login <distro> - login to distro
+$script login <distro> - login to distro
 "
 }
 
@@ -819,7 +820,7 @@ chroot_distro_backup() {
     # the content). If data/sdcard etc. are needed to backup then it is better to do it
     # with different tool (for example twrp) and/or from inside the chroot
     if chroot_distro_check_if_system_points_mounted "$distro_path"; then
-        echo "distro is potentially running - if needed shutdown the distro, and unmount system mount points ($0 unmount $1) before proceeding"
+        echo "distro is potentially running - if needed shutdown the distro, and unmount system mount points ($script unmount $1) before proceeding"
         exit
     fi
 
@@ -1013,8 +1014,8 @@ chroot_distro_login() {
 }
 
 chroot_distro_invalid_parameters() {
-    echo "$0 - $1"
-    echo "try '$0 help' for more information"
+    echo "$script - $1"
+    echo "try '$script help' for more information"
     exit 2
 }
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -62,19 +62,20 @@ $script download <distro> - download rootfs
 $script redownload <distro> - redownload rootfs
 $script delete <distro> - delete rootfs
 
-$script install <distro> [-d|--data] - install distro
-    '-d|--data' Installs also /data folder, by default not installed
-$script reinstall <distro> [-d|--data] - reinstall distro
-    '-d|--data' Installs also /data folder, by default not installed
+$script install <distro> [-a|--android] - install distro
+    '-a|--android' Installs also /data and /system folders, by default not installed
+$script reinstall <distro> [-a|--android] - reinstall distro
+    '-a|--android' Installs also /data and /system folders, by default not installed
 $script uninstall <distro> - uninstall distro
 
 $script unmount <distro> - unmount system mount points from distro
 
 $script backup <distro> [<path>] - backup distro
     <path>          Custom path for backup location
-$script restore <distro> [-d|--default] [<path>] - restore distro
+$script restore <distro> [-d|--default] [--force] [<path>] - restore distro
     <path>          Custom path for backup location
     '-d|--default'  restore default settings (note: only those set during install)
+    '--force'       Force restore even if may cause unintended side-effects
 $script unbackup <distro> - delete backup from default location
 
 $script command <distro> [--as-is] <command> - run command

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -661,13 +661,6 @@ chroot_distro_unmount_system_point() {
 
 chroot_distro_unmount_system_points() {
     distro_path="$1"
-    force="$2"
-    if [ "yes" = "$force" ]; then
-        : # do not check if data has been mounted, try to unmount it if possible
-    elif mountpoint -q "$distro_path/data" 2>/dev/null; then
-        echo "$distro_path/data is circular reference! unmount manually, or reboot before proceeding"
-        exit 1
-    fi
     for file in "/storage"/*; do
         # no need for separator as separator already comes from file variable itself
         chroot_distro_unmount_system_point "$distro_path$file"
@@ -803,7 +796,7 @@ chroot_distro_uninstall() {
 
     distro_path="$chroot_distro_path/$1"
     if [ -d "$distro_path" ]; then
-        chroot_distro_unmount_system_points "$distro_path" no
+        chroot_distro_unmount_system_points "$distro_path"
         mount_count=$(mount | grep -c "$distro_path")
         if [ "0" != "$mount_count" ]; then
             # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
@@ -995,7 +988,7 @@ chroot_distro_unmount() {
         exit 1
     fi
 
-    chroot_distro_unmount_system_points "$distro_path" yes
+    chroot_distro_unmount_system_points "$distro_path"
 }
 
 chroot_distro_command() {

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -692,12 +692,18 @@ chroot_distro_check_if_system_point_mounted() {
 
 chroot_distro_check_if_system_points_mounted() {
     distro_path="$1"
+    # shellcheck disable=SC2089
+    # quotes are intentionally added
     # dev/pts is not checked as it is assumed that if dev is mounted then also pts is mounted and if dev is not mounted then pts is not mounted
     system_paths="'$distro_path/dev' '$distro_path/sys' '$distro_path/proc' '$distro_path/sdcard' '$distro_path/system' '$distro_path/data'"
     for file in "/storage"/*; do
         # no need for separator as separator already comes from file variable itself
         system_paths="$system_paths '$distro_path$file'"
     done
+
+    # shellcheck disable=SC2090
+    # shellcheck disable=SC2086
+    # double quotes are intentionally omitted
     set -- $system_paths
     partial=
     quote="'"
@@ -756,7 +762,7 @@ chroot_distro_install() {
     fi
 
     common_path="$( chroot_distro_find_archive_common_path "$archive_path" )"
-    if [ "" == "$common_path" ]; then
+    if [ "" = "$common_path" ]; then
         common_path="."
     fi
     rootdir="$( echo "$common_path" | cut -f1 -d/ )"
@@ -906,7 +912,7 @@ chroot_distro_restore() {
     fi
 
     common_path="$(chroot_distro_find_archive_common_path "$backup_path")"
-    if [ "" == "$common_path" ]; then
+    if [ "" = "$common_path" ]; then
         common_path="."
     fi
     rootdir="$( echo "$common_path" | cut -f1 -d/ )"


### PR DESCRIPTION
Fixes #17
Ground work for #20

With this PR there should be no longer chances of removing too many files during uninstall. The problem was that the code did not check if there was already system mount point mounted at requested folder thus leading to situation where there could be multiple mount points pointing to same folder. This lead to situation where the code thought that everything was unmounted when instead there was x times the mounts and accidentally removed everything (or what ever it was possible with root permissions).

Also, at least with Termux the host side environment variables were leaked inside the jail. Code will now try to ensure that clean start up is achieved. This helps ensure that stuff running inside the jail will not accidentally use host side binaries / settings, and cause instability and/or unintended functionality.

Changed `--data` flag to `--android` flag to generalize the feature flag. This way `/data` and `/system` mount points are not mounted by default to prevent accidental modifications to them. With the latest changes they can be mounted without problems, even `/data` with circular reference.

Updated the documentation to reflect current functionality.