### PR TITLE
Fix rootfs without su

### DIFF
--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -736,6 +736,23 @@ chroot_distro_check_if_system_points_mounted() {
     return 1
 }
 
+chroot_distro_jail() {
+    distro_path=$1
+    # shellcheck disable=SC1007
+    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
+    # to prevent leaking host stuff to chroot to ensure consistent environment
+    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
+}
+
+chroot_distro_jail_command() {
+    distro_path=$1
+    command=$2
+    # shellcheck disable=SC1007
+    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
+    # to prevent leaking host stuff to chroot to ensure consistent environment
+    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root -c "$command"
+}
+
 chroot_distro_install() {
     distro=$1
     use_android=$2
@@ -784,10 +801,7 @@ chroot_distro_install() {
     chroot "$distro_path" /sbin/usermod -G 3003 -a root 2>/dev/null
     chroot "$distro_path" /bin/ln -sf /usr/share/zoneinfo/Asia/Taipei /etc/localtime 2>/dev/null
     chroot "$distro_path" /sbin/locale-gen en_US.UTF-8 2>/dev/null
-    # shellcheck disable=SC1007
-    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
-    # to prevent leaking host stuff to chroot to ensure consistent environment
-    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
+    chroot_distro_jail "$distro_path"
 }
 
 chroot_distro_uninstall() {
@@ -975,10 +989,7 @@ chroot_distro_restore() {
         chroot "$distro_path" /bin/ln -sf /usr/share/zoneinfo/Asia/Taipei /etc/localtime 2>/dev/null
         chroot "$distro_path" /sbin/locale-gen en_US.UTF-8 2>/dev/null
     fi
-    # shellcheck disable=SC1007
-    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
-    # to prevent leaking host stuff to chroot to ensure consistent environment
-    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
+    chroot_distro_jail "$distro_path"
 }
 
 chroot_distro_unmount() {
@@ -1019,10 +1030,7 @@ chroot_distro_command() {
         command="/bin/$2"
     fi
 
-    # shellcheck disable=SC1007
-    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
-    # to prevent leaking host stuff to chroot to ensure consistent environment
-    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root -c "$command"
+    chroot_distro_jail_command "$distro_path" "$command"
 }
 
 chroot_distro_login() {
@@ -1040,10 +1048,7 @@ chroot_distro_login() {
 
     chroot_distro_mount_system_points "$distro_path" no
 
-    # shellcheck disable=SC1007
-    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
-    # to prevent leaking host stuff to chroot to ensure consistent environment
-    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
+    chroot_distro_jail "$distro_path"
 }
 
 chroot_distro_invalid_parameters() {

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -780,6 +780,9 @@ chroot_distro_jail() {
     unset HISTFILE;
     unset TMPDIR;
     unset PREFIX;
+    unset BOOTCLASSPATH;
+    unset SYSTEMSERVERCLASSPATH;
+    unset LD_LIBRARY_PATH;
     SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" /system/bin/chroot "$distro_path/" /bin/sh -l
     )
 }
@@ -815,6 +818,9 @@ chroot_distro_jail_command() {
     unset HISTFILE;
     unset TMPDIR;
     unset PREFIX;
+    unset BOOTCLASSPATH;
+    unset SYSTEMSERVERCLASSPATH;
+    unset LD_LIBRARY_PATH;
     SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" /system/bin/chroot "$distro_path/" /bin/sh -lc "$command"
     )
 }

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -736,21 +736,87 @@ chroot_distro_check_if_system_points_mounted() {
     return 1
 }
 
+chroot_distro_find_su() {
+    root=$1
+    su_command=""
+    if [ -f "$root/bin/su" ] || [ -L "$root/bin/su" ]; then
+        su_command=/bin/su
+    elif [ -f "$root/usr/bin/su" ] || [ -L "$root/usr/bin/su" ]; then
+        su_command=/usr/bin/su
+    elif [ -f "$root/usr/local/bin/su" ] || [ -L "$root/usr/local/bin/su" ]; then
+        su_command=/usr/local/bin/su
+    fi
+    echo "$su_command"
+}
+
 chroot_distro_jail() {
     distro_path=$1
-    # shellcheck disable=SC1007
-    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
-    # to prevent leaking host stuff to chroot to ensure consistent environment
-    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root
+    su_command=$(chroot_distro_find_su "$distro_path")
+
+    if [ "" != "$su_command" ]; then
+        (
+        unset PREFIX;
+        # shellcheck disable=SC1007
+        # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
+        # to prevent leaking host stuff to chroot to ensure consistent environment
+        PATH= /system/bin/chroot "$distro_path/" "$su_command" - root
+        )
+        return
+    fi
+
+    echo "Warning: Missing 'su' command, can't do a proper login. Please, install 'su'"
+    echo "as soon as possible to ensure consistent login environment."
+
+    # ensure a sane PATH contents for the shell
+    JAIL_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+    JAIL_HOME=/
+    if [ -d "$distro_path/root" ]; then
+        JAIL_HOME=/root
+    fi
+
+    (
+    # try to ensure consistent environment
+    unset HISTFILE;
+    unset TMPDIR;
+    unset PREFIX;
+    SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" /system/bin/chroot "$distro_path/" /bin/sh -l
+    )
 }
 
 chroot_distro_jail_command() {
     distro_path=$1
     command=$2
-    # shellcheck disable=SC1007
-    # Termux adds its own stuff to PATH and many others, ensure that those are out of picture
-    # to prevent leaking host stuff to chroot to ensure consistent environment
-    PREFIX= PATH= /system/bin/chroot "$distro_path/" /bin/su - root -c "$command"
+    su_command=$(chroot_distro_find_su "$distro_path")
+
+    if [ "" != "$su_command" ]; then
+        (
+        unset PREFIX;
+        # shellcheck disable=SC1007
+        # try to ensure that su will do as proper login as possible to ensure consistent environment
+        PATH= /system/bin/chroot "$distro_path/" "$su_command" - root -c "$command"
+        )
+        return
+    fi
+
+    echo "Warning: Missing 'su' command, can't do a proper login to run the command."
+    echo "Please, install 'su' as soon as possible to ensure consistent login environment."
+
+    # ensure sane PATH contents for the shell
+    JAIL_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+    JAIL_HOME=/
+    if [ -d "$distro_path/root" ]; then
+        JAIL_HOME=/root
+    fi
+
+    (
+    # try to ensure consistent environment
+    unset HISTFILE;
+    unset TMPDIR;
+    unset PREFIX;
+    SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" /system/bin/chroot "$distro_path/" /bin/sh -lc "$command"
+    )
 }
 
 chroot_distro_install() {


### PR DESCRIPTION
Fixes #20.

Added better checks for `su` command trying to locate it from more places than previously. This should ensure that even if `su` is not in default location that chroot-distro will be able to use it.

If no `su` command is found then uses `/bin/sh` to login to jail, or to run a command. In this situation a warning is printed as there is no guarantee of a consistent environment (at least parts of host environment is leaked). The script tries to ensure that a consistent enough environment is available so that user can do at least some basic maintenance.