### PR TITLE
chroot-distro: fix up ubuntu selection

### DIFF
--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -190,38 +190,34 @@ Rootfs : https://github.com/EXALAB/Anlinux-Resources/raw/master/Rootfs/CentOS_St
 
 chroot_distro_download() {
     if [ "$1" = "ubuntu" ]; then
-        if [ "$hardware_machine" = "i386" ] || [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
-            echo "[1] ubuntu bionic 18.04.5"
-        fi
-        if [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
-            echo "[2] ubuntu focal 20.04.5"
-        fi
-        if [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
-            echo "[3] ubuntu jammy 22.04.4"
-        fi
-        if [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
-            echo "[4] ubuntu mantic 23.10"
-        fi
-        if [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
-            echo "[5] ubuntu noble 24.04"
+		if [ "$hardware_machine" = "i386" ] || [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
+            echo "[1] ubuntu trusty 14.04.6"
         fi
         if [ "$hardware_machine" = "i386" ] || [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
-            echo "[6] ubuntu trusty 14.04.6"
+            echo "[2] ubuntu xenial 16.04.6"
         fi
         if [ "$hardware_machine" = "i386" ] || [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
-            echo "[7] ubuntu xenial 16.04.6"
+            echo "[3] ubuntu bionic 18.04.5"
+        fi
+        if [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
+            echo "[4] ubuntu focal 20.04.5"
+        fi
+        if [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
+            echo "[5] ubuntu jammy 22.04.4"
+        fi
+        if [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
+            echo "[6] ubuntu noble 24.04.1"
         fi
         while true; do
             printf "Enter a number : "
             read number
             case "$number" in
-                1) rootfs="bionic";rootfs_version="18.04.5"; break;;
-                2) rootfs="focal";rootfs_version="20.04.5"; break;;
-                3) rootfs="jammy";rootfs_version="22.04.4"; break;;
-                4) rootfs="mantic";rootfs_version="23.10"; break;;
-                5) rootfs="noble";rootfs_version="24.04"; break;;
-                6) rootfs="trusty";rootfs_version="14.04.6"; break;;
-                7) rootfs="xenial";rootfs_version="16.04.6"; break;;
+                1) rootfs="trusty";rootfs_version="14.04.6"; break;;
+                2) rootfs="xenial";rootfs_version="16.04.6"; break;;
+                3) rootfs="bionic";rootfs_version="18.04.5"; break;;
+                4) rootfs="focal";rootfs_version="20.04.5"; break;;
+                5) rootfs="jammy";rootfs_version="22.04.4"; break;;
+                6) rootfs="noble";rootfs_version="24.04.1"; break;;
                 *) echo "Unknown option : $number";;
             esac
         done


### PR DESCRIPTION
fix for #35 and overall improvement of ubuntu selection

- cdimage.ubuntu.com no longer serves 23.10 so I removed it
- updated noble version since they added .1 to the end and removed 24.04 altogether which broke downloading rootfs
- reordered selection from older to newer