### PR TITLE
Fix/unmounts on newer devices

### DIFF
--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -661,7 +661,7 @@ chroot_distro_unmount_system_point() {
         # nothing to do, mount point missing
         return
     fi
-    if ! mountpoint -q "$mount_point" 2>/dev/null; then
+    if ! mountpoint -q "$mount_point"; then
         # nothing to do, already unmounted
         return
     fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -665,8 +665,8 @@ chroot_distro_unmount_system_point() {
         # nothing to do, already unmounted
         return
     fi
-    if ! umount -lf "$mount_point"; then
-        echo "could not unmount $mount_point, uninstall may need manual intervention, proceed with care"
+    if ! umount "$mount_point"; then
+        echo "could not unmount $mount_point, distro is potentially running - if needed shutdown the distro, and try again"
         exit 1
     fi
 }


### PR DESCRIPTION
Fixes #33.

Get rid of lazy unmounting as it should be used only as a last resort. Also, don't use force on bind mounts as it may cause problems with some kernel versions by causing transportation endpoint missing errors.