### PR TITLE
Fix KernelSU/APatch/Magisk without separately installed Busybox NDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ chroot-distro :
 
 ### Installation requirements
 
-Reasonably new Busybox-ndk magisk module version installed (1.36.1 is known to work, 1.32.1 is known to not work). If new enough version is not installed it may lead to problems with downloading rootfs.
+Reasonably new Busybox-ndk magisk module version installed (1.36.1 is known to work, 1.32.1 is known to not work). If new enough version is not installed it may lead to problems, for example with downloading rootfs. Using Busybox provided by KernelSU/APatch (ie. without Busybox-ndk magisk module) is community supported, and may lead to bugs during usage.
 
 ### Android paths on distributions :
 + /dev 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ chroot-distro :
 
 ### Installation requirements
 
-Reasonably new Busybox-ndk magisk module version installed (1.36.1 is known to work, 1.32.1 is known to not work). If new enough version is not installed it may lead to problems, for example with downloading rootfs. Using Busybox provided by KernelSU/APatch (ie. without Busybox-ndk magisk module) is community supported, and may lead to bugs during usage.
+Reasonably new Busybox-ndk magisk module version installed (1.36.1 is known to work, 1.32.1 is known to not work). If new enough version is not installed it may lead to problems, for example with downloading rootfs. Using Busybox provided by Magisk/KernelSU/APatch (ie. without Busybox-ndk magisk module) is community supported, and may lead to bugs during usage.
 
 ### Android paths on distributions :
 + /dev 
@@ -33,6 +33,10 @@ As they say: *With great power comes great responsibility.*
 + help
 ```
 chroot-distro help
+```
++ output debug information about environment
+```
+chroot-distro env
 ```
 + list of available linux distributions
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ chroot-distro :
 
 ### Installation requirements
 
-Reasonably new Busybox-ndk magisk module version installed (1.36.1 is known to work, 1.32.1 is known to not work). If new enough version is not installed it may lead to problems, for example with downloading rootfs. Using Busybox provided by Magisk/KernelSU/APatch (ie. without Busybox-ndk magisk module) is community supported, and may lead to bugs during usage.
+Reasonably new Busybox for Android NDK Magisk module version installed (1.36.1 is known to work, 1.32.1 is known to not work). If new enough version is not installed it may lead to problems, for example with downloading rootfs. Using Busybox provided by Magisk/KernelSU/APatch (ie. without Busybox for Android NDK Magisk module) is community supported, and may lead to bugs during usage.
 
 ### Android paths on distributions :
 + /dev 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -38,9 +38,16 @@ elif [ -e /data/adb/modules/chroot-distro ]; then
     hash=$(md5sum "$0" | cut -d " " -f1)
     if cmp --silent "$0" /data/adb/modules/chroot-distro/system/bin/chroot-distro; then
         (
-            # shellcheck disable=SC1091
-            . /data/adb/modules/chroot-distro/module.prop && true
-            echo "Version: ${version:-'Unknown'} (${versionCode:-'??'}), md5 hash: $hash"
+            module_prop=$(cat /data/adb/modules/chroot-distro/module.prop)
+            echo "$module_prop" | while read -r row; do
+                field=$(echo "$row" | cut -d "=" -f 1 )
+                value=$(echo "$row" | cut -d "=" -f 2 )
+                case "$field" in
+                    version) echo "Version: $value" ;;
+                    versionCode) echo "Versioncode: $value" ;;
+                esac
+            done
+            echo "md5 hash: $hash"
         )
     else
         echo "Not matching installed version, md5 hash: $hash"

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -119,6 +119,12 @@ busybox() { "$busyboxpath" "$@"; }
 # toybox does not support -p
 uname() { busybox uname "$@"; }
 
+# ensure that busybox version of getopt is used
+getopt() { busybox getopt "$@"; }
+
+# ensure that busybox version of tar is used
+tar() { busybox tar "$@"; }
+
 if [ "" != "$check_env" ]; then
     if [ ! -e /data/adb ]; then
         echo 'Could not determine the type of root solution installed'
@@ -160,9 +166,6 @@ if [ "" != "$check_env" ]; then
     exit 0
 fi
 
-# ensure that busybox version of getopt is used
-getopt() { busybox getopt "$@"; }
-
 getopt --test > /dev/null && true
 if [ $? -ne 4 ]; then
     # shellcheck disable=SC2016
@@ -173,9 +176,6 @@ fi
 
 # get a unique name
 non_existent_file=$(mktemp -u)
-
-# ensure that busybox version of tar is used
-tar() { busybox tar "$@"; }
 
 tar_output=$(tar -t -J -f "$non_existent_file.tar.xz" 2>&1)
 if [ "1" = $(echo "$tar_output" | grep -i -c "(invalid|unknown) option") ]; then

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -20,10 +20,13 @@ if [ $? -ne 0 ]; then
     echo "busybox not found, install busybox for Android NDK and try again"
     exit 1
 fi
+unsupported_busybox=''
 case "$busyboxpath" in
     /bin/*) ;; # assume that it is ok (either old android, or linux), nothing to do
     /system/*) ;; # busybox in system partition, nothing to do
     /usr/bin/*) ;; # running linux, assume that all is ok, nothing to do
+    /data/adb/ksu/bin/*) unsupported_busybox=true ;; # KernelSU without Busybox Android NDK installed
+    /data/adb/ap/bin/*) unsupported_busybox=true ;; # APatch without Busybox Android NDK installed
     *)
         echo "busybox not found from the expected path, ensure that busybox for Android NDK has been installed and try again"
         exit 1
@@ -43,7 +46,7 @@ non_existent_file=$(mktemp -u)
 tar_supports_xz=true
 tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
 if [ $? -eq 1 ]; then
-    tar_supports_xz=""
+    tar_supports_xz=''
 fi
 
 unset non_existent_file
@@ -72,7 +75,12 @@ else
     exit 1
 fi
 
-
+chroot_distro_warn_if_unsupported_busybox() {
+    if [ "" != "$unsupported_busybox" ]; then
+        echo "Warning: You are using KernelSU/APatch without Busybox Android NDK installed."
+        echo "You may exprience bugs as this is community supported environment."
+    fi
+}
 
 chroot_distro_help() {
     echo "$script : install linux distributions
@@ -105,6 +113,8 @@ $script unbackup <distro> - delete backup from default location
 $script command <distro> <command> - run command
 $script login <distro> - login to distro
 "
+
+    chroot_distro_warn_if_unsupported_busybox
 }
 
 chroot_distro_list_item() {
@@ -202,7 +212,7 @@ Rootfs : https://github.com/EXALAB/Anlinux-Resources/raw/master/Rootfs/CentOS_St
 
 chroot_distro_download() {
     if [ "$1" = "ubuntu" ]; then
-		if [ "$hardware_machine" = "i386" ] || [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
+        if [ "$hardware_machine" = "i386" ] || [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
             echo "[1] ubuntu trusty 14.04.6"
         fi
         if [ "$hardware_machine" = "i386" ] || [ "$hardware_machine" = "arm64" ] || [ "$hardware_machine" = "armhf" ] || [ "$hardware_machine" = "amd64" ]; then
@@ -1302,6 +1312,7 @@ elif [ "$command" = "download" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
+    chroot_distro_warn_if_unsupported_busybox
     chroot_distro_download "$1"
 elif [ "$command" = "redownload" ]; then
     PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
@@ -1370,6 +1381,7 @@ elif [ "$command" = "install" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
+    chroot_distro_warn_if_unsupported_busybox
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "uninstall" ]; then
     PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -120,7 +120,18 @@ case "$busyboxpath" in
 esac
 
 busyboxdir="$(dirname "$busyboxpath")"
-if [ "" != "$busyboxpath" ] && [ "/system/bin" != "$busyboxdir" ] && [ -e "$busyboxdir"/chroot ]; then
+can_use_busyboxdir=true
+if [ "" = "$busyboxpath" ]; then
+    # not found
+    can_use_busyboxdir=''
+elif [ "/system/bin" = "$busyboxdir" ]; then
+    # would use toybox version always, skip
+    can_use_busyboxdir=''
+elif [ "/usr/bin" = "$busyboxdir" ]; then
+    # would use full/normal chroot command, skip to ensure consistent test environment
+    can_use_busyboxdir=''
+fi
+if [ "" != "$can_use_busyboxdir" ] &&  [ -e "$busyboxdir"/chroot ]; then
     # Use chroot from the expected Busybox, but not the toybox version
     chrootpath="$(dirname "$busyboxpath")"/chroot
 elif [ -e /system/xbin/chroot ]; then
@@ -133,6 +144,7 @@ else
     # don't want to use a random chroot to ensure it doesn't affect the jail
     chrootpath=''
 fi
+unset can_use_busyboxdir
 unset busyboxdir
 
 if [ "" = "$check_env" ] && [ "" = "$chrootpath" ]; then

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -167,8 +167,8 @@ non_existent_file=$(mktemp -u)
 # ensure that busybox version of tar is used
 tar() { busybox tar "$@"; }
 
-tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
-if [ $? -eq 1 ]; then
+tar_output=$(tar -t -J -f "$non_existent_file.tar.xz" 2>&1)
+if [ "1" = $(echo "$tar_output" | grep -i -c "(invalid|unknown) option") ]; then
     echo 'Your Busybox tar does not support xz compression. Update your busybox!'
     echo "Run '$script env' for extra information"
     exit 1

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -49,10 +49,10 @@ non_existent_file=$(mktemp -u)
 # ensure that busybox version of tar is used
 tar() { busybox tar "$@"; }
 
-tar_supports_xz=true
 tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
 if [ $? -eq 1 ]; then
-    tar_supports_xz=''
+    echo 'Your Busybox tar does not support xz compression. Update your busybox!'
+    exit 1
 fi
 
 unset non_existent_file
@@ -888,22 +888,12 @@ chroot_distro_install() {
     fi
     if [ "." = "$rootdir" ]; then
         mkdir "$distro_path"
-        if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$archive_path" | tar -x -C "$distro_path/"
-        else
-            tar -xf "$archive_path" -C "$distro_path/"
-        fi
-        # shellcheck disable=SC2181
-        if [ $? -ne 0 ]; then
+        if ! tar -xf "$archive_path" -C "$distro_path/"; then
             echo "Error: Unpacking the archive failed"
             exit 5
         fi
     else
-        if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$archive_path" | tar -x -C "$chroot_distro_path/"
-        else
-            tar -xf "$archive_path" -C "$chroot_distro_path/"
-        fi
+        tar -xf "$archive_path" -C "$chroot_distro_path/"
         tar_status=$?
         if [ $tar_status -ne 0 ] && [ ! -e "$chroot_distro_path/$rootdir" ]; then
             # can bail out early as no files were unpacked
@@ -1000,12 +990,7 @@ chroot_distro_backup() {
         fi
         (
             cd "$chroot_distro_path" || exit 1;
-            if [ "" = "$tar_supports_xz" ]; then
-                # use gzip compression as xz is not supported
-                tar -czvf "$backup_path" "$distro"
-            else
-                tar -cvf "$backup_path" "$distro"
-            fi
+            tar -cvf "$backup_path" "$distro"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1015,18 +1000,7 @@ chroot_distro_backup() {
     else
         (
             cd "$chroot_distro_path" || exit 1;
-            case "$2" in
-                *.tar.xz) {
-                    if [ "" = "$tar_supports_xz" ]; then
-                        # use gzip compression as xz is not supported
-                        tar -czvf "$2" "$distro"
-                    else
-                        tar -cJvf "$2" "$distro"
-                    fi
-                } ;;
-                # rely on compression autodetection
-                *) tar -cvf "$2" "$distro" ;;
-            esac;
+            tar -cvf "$2" "$distro"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1043,12 +1017,7 @@ chroot_distro_find_archive_common_path() {
         echo "Error: unsupported or corrupt archive"
         exit 5
     fi
-    if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-        # archive uses xz but tar does not support it natively
-        paths_to_check="$(xz -cd "$archive_path" | tar -t 2>/dev/null)"
-    else
-        paths_to_check="$(tar -tf "$archive_path" 2>/dev/null)"
-    fi
+    paths_to_check="$(tar -tf "$archive_path" 2>/dev/null)"
 
     i=1
     prev_path=
@@ -1125,11 +1094,7 @@ chroot_distro_restore() {
     if [ "." = "$rootdir" ]; then
         # backup has relative path, restoring is not a problem
         mkdir "$distro_path"
-        if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$backup_path" | tar -x -C "$distro_path/"
-        else
-            tar -xf "$backup_path" -C "$distro_path/"
-        fi
+        tar -xf "$backup_path" -C "$distro_path/"
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
             echo "Error: Unpacking the archive failed"
@@ -1142,11 +1107,7 @@ chroot_distro_restore() {
         # fill the internal storage. There is also possibility of using wrong backup.
         (
             cd /
-            if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-                xz -cd "$backup_path" | tar -x
-            else
-                tar -xf "$backup_path"
-            fi
+            tar -xf "$backup_path"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1168,11 +1129,7 @@ chroot_distro_restore() {
         # new format backups
         (
             cd "$chroot_distro_path" || exit 1;
-            if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-                xz -cd "$backup_path" | tar -x
-            else
-                tar -xf "$backup_path"
-            fi
+            tar -xf "$backup_path"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -127,6 +127,9 @@ getopt() { busybox getopt "$@"; }
 # ensure that busybox version of tar is used
 tar() { busybox tar "$@"; }
 
+# ensure that busybox version of wget is used
+wget() { busybox wget "$@"; }
+
 if [ "" != "$check_env" ]; then
     if [ ! -e /data/adb ]; then
         echo 'Could not determine the type of root solution installed'

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -33,7 +33,7 @@ case "$busyboxpath" in
     ;;
 esac
 
-getopt --test > /dev/null && true
+busybox getopt --test > /dev/null && true
 if [ $? -ne 4 ]; then
     # shellcheck disable=SC2016
     echo 'I'\''m sorry, `getopt --test` failed in this environment.'
@@ -1271,10 +1271,10 @@ command=$1
 shift
 
 if [ "$command" = "help" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     chroot_distro_help
 elif [ "$command" = "list" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1293,7 +1293,7 @@ elif [ "$command" = "list" ]; then
     fi
     chroot_distro_list
 elif [ "$command" = "download" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1315,7 +1315,7 @@ elif [ "$command" = "download" ]; then
     chroot_distro_warn_if_unsupported_busybox
     chroot_distro_download "$1"
 elif [ "$command" = "redownload" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1336,7 +1336,7 @@ elif [ "$command" = "redownload" ]; then
     fi
     chroot_distro_download "$1"
 elif [ "$command" = "delete" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1357,7 +1357,7 @@ elif [ "$command" = "delete" ]; then
     fi
     chroot_distro_delete "$1"
 elif [ "$command" = "install" ]; then
-    PARSED=$(getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     android=no
     while true; do
@@ -1384,7 +1384,7 @@ elif [ "$command" = "install" ]; then
     chroot_distro_warn_if_unsupported_busybox
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "uninstall" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1405,7 +1405,7 @@ elif [ "$command" = "uninstall" ]; then
     fi
     chroot_distro_uninstall "$1"
 elif [ "$command" = "reinstall" ]; then
-    PARSED=$(getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     android=no
     while true; do
@@ -1432,7 +1432,7 @@ elif [ "$command" = "reinstall" ]; then
     chroot_distro_uninstall "$1"
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "backup" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1453,7 +1453,7 @@ elif [ "$command" = "backup" ]; then
     fi
     chroot_distro_backup "$1" "$2"
 elif [ "$command" = "unbackup" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1475,7 +1475,7 @@ elif [ "$command" = "unbackup" ]; then
     chroot_distro_unbackup "$1"
 elif [ "$command" = "restore" ]; then
     OPTS=d LONGOPTS=default,force
-    PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     restore_defaults=no
     force=no
@@ -1506,7 +1506,7 @@ elif [ "$command" = "restore" ]; then
     fi
     chroot_distro_restore "$1" "$2" "$restore_defaults" "$force"
 elif [ "$command" = "command" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1529,7 +1529,7 @@ elif [ "$command" = "command" ]; then
     fi
     chroot_distro_command "$1" "$2"
 elif [ "$command" = "login" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1550,7 +1550,7 @@ elif [ "$command" = "login" ]; then
     fi
     chroot_distro_login "$1"
 elif [ "$command" = "unmount" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -36,7 +36,7 @@ if [ "" = "$check_env" ]; then
 elif [ -e /data/adb/modules/chroot-distro ]; then
     echo "Script: $0"
     hash=$(md5sum "$0" | cut -d " " -f1)
-    if cmp --silent "$0" /data/adb/modules/chroot-distro/system/bin/chroot-distro; then
+    if cmp -s "$0" /data/adb/modules/chroot-distro/system/bin/chroot-distro; then
         (
             module_prop=$(cat /data/adb/modules/chroot-distro/module.prop)
             echo "$module_prop" | while read -r row; do
@@ -113,6 +113,12 @@ case "$busyboxpath" in
     ;;
 esac
 
+# ensure that the expected version of busybox is used
+busybox() { "$busyboxpath" "$@"; }
+
+# toybox does not support -p
+uname() { busybox uname "$@"; }
+
 if [ "" != "$check_env" ]; then
     if [ ! -e /data/adb ]; then
         echo 'Could not determine the type of root solution installed'
@@ -153,9 +159,6 @@ if [ "" != "$check_env" ]; then
     # check run successfully, bail out
     exit 0
 fi
-
-# ensure that the expected version of busybox is used
-busybox() { "$busyboxpath" "$@"; }
 
 # ensure that busybox version of getopt is used
 getopt() { busybox getopt "$@"; }

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -132,7 +132,7 @@ elif [ "/usr/bin" = "$busyboxdir" ]; then
     can_use_busyboxdir=''
 fi
 if [ "" != "$can_use_busyboxdir" ] &&  [ -e "$busyboxdir"/chroot ]; then
-    # Use chroot from the expected Busybox, but not the toybox version
+    # Use chroot from the expected Busybox
     chrootpath="$(dirname "$busyboxpath")"/chroot
 elif [ -e /system/xbin/chroot ]; then
     # Use a Busybox version
@@ -156,7 +156,7 @@ fi
 # ensure that the expected version of busybox is used
 busybox() { "$busyboxpath" "$@"; }
 
-# Toybox does not support -p
+# Toybox uname does not support -p
 uname() {
     if [ "" != "$busyboxpath" ]; then
         busybox uname "$@";

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -212,6 +212,13 @@ if [ "" != "$check_env" ]; then
         done
         echo 'list end'
     fi
+    if [ ! -e /data/adb ]; then
+        echo 'Could not determine if Busybox for Android NDK Magisk module is installed'
+    elif [ -e /data/adb/modules/busybox-ndk ]; then
+        echo 'Busybox for Android NDK Magisk module installed'
+    else
+        echo 'Busybox for Android NDK Magisk module not installed'
+    fi
     # don't want machine name, otherwise -a would be easiest
     if [ "unknown" != "$(uname -p)" ]; then
         uname -s -r -v -m -p -i -o

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -33,7 +33,10 @@ case "$busyboxpath" in
     ;;
 esac
 
-busybox getopt --test > /dev/null && true
+# ensure that busybox version of getopt is used
+getopt() { busybox getopt "$@"; }
+
+getopt --test > /dev/null && true
 if [ $? -ne 4 ]; then
     # shellcheck disable=SC2016
     echo 'I'\''m sorry, `getopt --test` failed in this environment.'
@@ -43,8 +46,11 @@ fi
 # get a unique name
 non_existent_file=$(mktemp -u)
 
+# ensure that busybox version of tar is used
+tar() { busybox tar "$@"; }
+
 tar_supports_xz=true
-busybox tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
+tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
 if [ $? -eq 1 ]; then
     tar_supports_xz=''
 fi
@@ -883,9 +889,9 @@ chroot_distro_install() {
     if [ "." = "$rootdir" ]; then
         mkdir "$distro_path"
         if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$archive_path" | busybox tar -x -C "$distro_path/"
+            xz -cd "$archive_path" | tar -x -C "$distro_path/"
         else
-            busybox tar -xf "$archive_path" -C "$distro_path/"
+            tar -xf "$archive_path" -C "$distro_path/"
         fi
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -894,9 +900,9 @@ chroot_distro_install() {
         fi
     else
         if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$archive_path" | busybox tar -x -C "$chroot_distro_path/"
+            xz -cd "$archive_path" | tar -x -C "$chroot_distro_path/"
         else
-            busybox tar -xf "$archive_path" -C "$chroot_distro_path/"
+            tar -xf "$archive_path" -C "$chroot_distro_path/"
         fi
         tar_status=$?
         if [ $tar_status -ne 0 ] && [ ! -e "$chroot_distro_path/$rootdir" ]; then
@@ -996,9 +1002,9 @@ chroot_distro_backup() {
             cd "$chroot_distro_path" || exit 1;
             if [ "" = "$tar_supports_xz" ]; then
                 # use gzip compression as xz is not supported
-                busybox tar -czvf "$backup_path" "$distro"
+                tar -czvf "$backup_path" "$distro"
             else
-                busybox tar -cvf "$backup_path" "$distro"
+                tar -cvf "$backup_path" "$distro"
             fi
         )
         # shellcheck disable=SC2181
@@ -1013,13 +1019,13 @@ chroot_distro_backup() {
                 *.tar.xz) {
                     if [ "" = "$tar_supports_xz" ]; then
                         # use gzip compression as xz is not supported
-                        busybox tar -czvf "$2" "$distro"
+                        tar -czvf "$2" "$distro"
                     else
-                        busybox tar -cJvf "$2" "$distro"
+                        tar -cJvf "$2" "$distro"
                     fi
                 } ;;
                 # rely on compression autodetection
-                *) busybox tar -cvf "$2" "$distro" ;;
+                *) tar -cvf "$2" "$distro" ;;
             esac;
         )
         # shellcheck disable=SC2181
@@ -1039,9 +1045,9 @@ chroot_distro_find_archive_common_path() {
     fi
     if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
         # archive uses xz but tar does not support it natively
-        paths_to_check="$(xz -cd "$archive_path" | busybox tar -t 2>/dev/null)"
+        paths_to_check="$(xz -cd "$archive_path" | tar -t 2>/dev/null)"
     else
-        paths_to_check="$(busybox tar -tf "$archive_path" 2>/dev/null)"
+        paths_to_check="$(tar -tf "$archive_path" 2>/dev/null)"
     fi
 
     i=1
@@ -1120,9 +1126,9 @@ chroot_distro_restore() {
         # backup has relative path, restoring is not a problem
         mkdir "$distro_path"
         if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$backup_path" | busybox tar -x -C "$distro_path/"
+            xz -cd "$backup_path" | tar -x -C "$distro_path/"
         else
-            busybox tar -xf "$backup_path" -C "$distro_path/"
+            tar -xf "$backup_path" -C "$distro_path/"
         fi
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1137,9 +1143,9 @@ chroot_distro_restore() {
         (
             cd /
             if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-                xz -cd "$backup_path" | busybox tar -x
+                xz -cd "$backup_path" | tar -x
             else
-                busybox tar -xf "$backup_path"
+                tar -xf "$backup_path"
             fi
         )
         # shellcheck disable=SC2181
@@ -1163,9 +1169,9 @@ chroot_distro_restore() {
         (
             cd "$chroot_distro_path" || exit 1;
             if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-                xz -cd "$backup_path" | busybox tar -x
+                xz -cd "$backup_path" | tar -x
             else
-                busybox tar -xf "$backup_path"
+                tar -xf "$backup_path"
             fi
         )
         # shellcheck disable=SC2181
@@ -1271,10 +1277,10 @@ command=$1
 shift
 
 if [ "$command" = "help" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     chroot_distro_help
 elif [ "$command" = "list" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1293,7 +1299,7 @@ elif [ "$command" = "list" ]; then
     fi
     chroot_distro_list
 elif [ "$command" = "download" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1315,7 +1321,7 @@ elif [ "$command" = "download" ]; then
     chroot_distro_warn_if_unsupported_busybox
     chroot_distro_download "$1"
 elif [ "$command" = "redownload" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1336,7 +1342,7 @@ elif [ "$command" = "redownload" ]; then
     fi
     chroot_distro_download "$1"
 elif [ "$command" = "delete" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1357,7 +1363,7 @@ elif [ "$command" = "delete" ]; then
     fi
     chroot_distro_delete "$1"
 elif [ "$command" = "install" ]; then
-    PARSED=$(busybox getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     android=no
     while true; do
@@ -1384,7 +1390,7 @@ elif [ "$command" = "install" ]; then
     chroot_distro_warn_if_unsupported_busybox
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "uninstall" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1405,7 +1411,7 @@ elif [ "$command" = "uninstall" ]; then
     fi
     chroot_distro_uninstall "$1"
 elif [ "$command" = "reinstall" ]; then
-    PARSED=$(busybox getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     android=no
     while true; do
@@ -1432,7 +1438,7 @@ elif [ "$command" = "reinstall" ]; then
     chroot_distro_uninstall "$1"
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "backup" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1453,7 +1459,7 @@ elif [ "$command" = "backup" ]; then
     fi
     chroot_distro_backup "$1" "$2"
 elif [ "$command" = "unbackup" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1475,7 +1481,7 @@ elif [ "$command" = "unbackup" ]; then
     chroot_distro_unbackup "$1"
 elif [ "$command" = "restore" ]; then
     OPTS=d LONGOPTS=default,force
-    PARSED=$(busybox getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     restore_defaults=no
     force=no
@@ -1506,7 +1512,7 @@ elif [ "$command" = "restore" ]; then
     fi
     chroot_distro_restore "$1" "$2" "$restore_defaults" "$force"
 elif [ "$command" = "command" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1529,7 +1535,7 @@ elif [ "$command" = "command" ]; then
     fi
     chroot_distro_command "$1" "$2"
 elif [ "$command" = "login" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in
@@ -1550,7 +1556,7 @@ elif [ "$command" = "login" ]; then
     fi
     chroot_distro_login "$1"
 elif [ "$command" = "unmount" ]; then
-    PARSED=$(busybox getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     while true; do
         case "$1" in

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -67,7 +67,7 @@ busyboxpath="$(command -v busybox 2> /dev/null)"
 if [ $? -ne 0 ]; then
     busyboxpath=''
     if [ -e /data/adb ]; then
-        # try harder... -- thanks for the pointer, @osm0osis
+        # try harder... -- thanks for the pointer, @osm0sis
         if [ "" != "$check_env" ]; then
             echo 'Checking for hidden Busyboxes'
         fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -17,8 +17,19 @@ busyboxpath="$(command -v busybox 2> /dev/null)"
 # shellcheck disable=SC2181
 # need both ouput and error code thus needs indirect error checking
 if [ $? -ne 0 ]; then
-    echo "busybox not found, install busybox for Android NDK and try again"
-    exit 1
+    busyboxpath=''
+    if [ -e /data/adb ]; then
+        # try harder... thanks @osm0osis
+        for possiblepath in /data/adb/modules/busybox-ndk/system/*/busybox /data/adb/magisk/busybox /data/adb/ksu/bin/busybox /data/adb/ap/bin/busybox; do
+            if [ "" = "$busyboxpath" ] && [ -f "$possiblepath" ]; then
+                busyboxpath="$possiblepath"
+            fi
+        done;
+    fi
+    if [ "" = "$busyboxpath" ]; then
+        echo "busybox not found, install busybox for Android NDK and try again"
+        exit 1
+    fi
 fi
 unsupported_busybox=''
 case "$busyboxpath" in
@@ -30,6 +41,8 @@ case "$busyboxpath" in
             busyboxpath="$ndk_path"
         fi
     ;;
+    /data/adb/modules/busybox-ndk/system/*) ;; # hidden Busybox for Android NDK, nothing to do
+    /data/adb/magisk/*) unsupported_busybox=true ;; # Magisk without Busybox Android NDK installed
     /usr/bin/*) ;; # running linux, assume that all is ok, nothing to do
     /data/adb/ksu/bin/*) unsupported_busybox=true ;; # KernelSU without Busybox Android NDK installed
     /data/adb/ap/bin/*) unsupported_busybox=true ;; # APatch without Busybox Android NDK installed
@@ -92,8 +105,8 @@ fi
 
 chroot_distro_warn_if_unsupported_busybox() {
     if [ "" != "$unsupported_busybox" ]; then
-        echo "Warning: You are using KernelSU/APatch without Busybox Android NDK installed."
-        echo "You may exprience bugs as this is community supported environment."
+        echo "Warning: You are using Magisk/KernelSU/APatch without Busybox Android NDK installed."
+        echo "You may experience bugs as this is community supported environment."
     fi
 }
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -78,7 +78,7 @@ if [ $? -ne 0 ]; then
         done;
     fi
     if [ "" = "$check_env" ] && [ "" = "$busyboxpath" ]; then
-        echo "busybox not found, install busybox for Android NDK and try again"
+        echo "busybox not found, install Busybox for Android NDK and try again"
         echo "Run '$script env' for extra information"
         exit 1
     fi
@@ -106,13 +106,13 @@ case "$busyboxpath" in
         fi
     ;;
     /data/adb/modules/busybox-ndk/system/*) ;; # hidden Busybox for Android NDK, nothing to do
-    /data/adb/magisk/*) unsupported_busybox=true ;; # Magisk without Busybox Android NDK installed
+    /data/adb/magisk/*) unsupported_busybox=true ;; # Magisk without Busybox for Android NDK installed
     /usr/bin/*) ;; # running linux, assume that all is ok, nothing to do
-    /data/adb/ksu/bin/*) unsupported_busybox=true ;; # KernelSU without Busybox Android NDK installed
-    /data/adb/ap/bin/*) unsupported_busybox=true ;; # APatch without Busybox Android NDK installed
+    /data/adb/ksu/bin/*) unsupported_busybox=true ;; # KernelSU without Busybox for Android NDK installed
+    /data/adb/ap/bin/*) unsupported_busybox=true ;; # APatch without Busybox for Android NDK installed
     *)
         if [ "" = "$check_env" ]; then
-            echo "busybox not found from the expected path, ensure that busybox for Android NDK has been installed and try again"
+            echo "busybox not found from the expected path, ensure that Busybox for Android NDK has been installed and try again"
             echo "Run '$script env' for extra information"
             exit 1
         fi
@@ -125,7 +125,7 @@ if [ "" = "$busyboxpath" ]; then
     # not found
     can_use_busyboxdir=''
 elif [ "/system/bin" = "$busyboxdir" ]; then
-    # would use toybox version always, skip
+    # would use Toybox version always, skip
     can_use_busyboxdir=''
 elif [ "/usr/bin" = "$busyboxdir" ]; then
     # would use full/normal chroot command, skip to ensure consistent test environment
@@ -135,10 +135,10 @@ if [ "" != "$can_use_busyboxdir" ] &&  [ -e "$busyboxdir"/chroot ]; then
     # Use chroot from the expected Busybox, but not the toybox version
     chrootpath="$(dirname "$busyboxpath")"/chroot
 elif [ -e /system/xbin/chroot ]; then
-    # Use a busybox version
+    # Use a Busybox version
     chrootpath=/system/xbin/chroot
 elif [ -e /system/bin/chroot ]; then
-    # Fall back to toybox version
+    # Fall back to Toybox version
     chrootpath=/system/bin/chroot
 else
     # don't want to use a random chroot to ensure it doesn't affect the jail
@@ -148,7 +148,7 @@ unset can_use_busyboxdir
 unset busyboxdir
 
 if [ "" = "$check_env" ] && [ "" = "$chrootpath" ]; then
-    echo "chroot not found from the expected path, ensure that busybox for Android NDK has been installed and try again"
+    echo "chroot not found from the expected path, ensure that Busybox for Android NDK has been installed and try again"
     echo "Run '$script env' for extra information"
     exit 1
 fi
@@ -156,7 +156,7 @@ fi
 # ensure that the expected version of busybox is used
 busybox() { "$busyboxpath" "$@"; }
 
-# toybox does not support -p
+# Toybox does not support -p
 uname() {
     if [ "" != "$busyboxpath" ]; then
         busybox uname "$@";
@@ -263,7 +263,7 @@ fi
 
 chroot_distro_warn_if_unsupported_busybox() {
     if [ "" != "$unsupported_busybox" ]; then
-        echo "Warning: You are using Magisk/KernelSU/APatch without Busybox Android NDK installed."
+        echo "Warning: You are using Magisk/KernelSU/APatch without Busybox for Android NDK installed."
         echo "You may experience bugs as this is community supported environment."
     fi
 }

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -108,8 +108,10 @@ case "$busyboxpath" in
     /data/adb/ksu/bin/*) unsupported_busybox=true ;; # KernelSU without Busybox Android NDK installed
     /data/adb/ap/bin/*) unsupported_busybox=true ;; # APatch without Busybox Android NDK installed
     *)
-        echo "busybox not found from the expected path, ensure that busybox for Android NDK has been installed and try again"
-        exit 1
+        if [ "" = "$check_env" ]; then
+            echo "busybox not found from the expected path, ensure that busybox for Android NDK has been installed and try again"
+            exit 1
+        fi
     ;;
 esac
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -77,7 +77,7 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ "" != "$check_env" ]; then
-    echo "Busybox => '$busyboxpath'"
+    echo "busybox => '$busyboxpath'"
     echo "Busybox version: $($busyboxpath | head -n1)"
 fi
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -23,7 +23,13 @@ fi
 unsupported_busybox=''
 case "$busyboxpath" in
     /bin/*) ;; # assume that it is ok (either old android, or linux), nothing to do
-    /system/*) ;; # busybox in system partition, nothing to do
+    /system/*)
+        ndk_path=/system/xbin/busybox
+        if [ "$busyboxpath" != "$ndk_path" ] && [ -e "$ndk_path" ]; then
+            # force use of Busybox for Android NDK in the case there is conflicting versions
+            busyboxpath="$ndk_path"
+        fi
+    ;;
     /usr/bin/*) ;; # running linux, assume that all is ok, nothing to do
     /data/adb/ksu/bin/*) unsupported_busybox=true ;; # KernelSU without Busybox Android NDK installed
     /data/adb/ap/bin/*) unsupported_busybox=true ;; # APatch without Busybox Android NDK installed
@@ -32,6 +38,9 @@ case "$busyboxpath" in
         exit 1
     ;;
 esac
+
+# ensure that the expected version of busybox is used
+busybox() { "$busyboxpath" "$@"; }
 
 # ensure that busybox version of getopt is used
 getopt() { busybox getopt "$@"; }

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -13,6 +13,47 @@ if [ "$(whoami)" != "root" ]; then
     exit 1
 fi
 
+if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+    hardware_machine="arm64"
+elif [ "$(uname -m)" = "arm" ] || [ "$(uname -m)" = "armel" ] || [ "$(uname -m)" = "armhf" ] || [ "$(uname -m)" = "armhfp" ] || [ "$(uname -m)" = "armv7" ] || [ "$(uname -m)" = "armv7l" ] || [ "$(uname -m)" = "armv7a" ] || [ "$(uname -m)" = "armv8l" ]; then
+    hardware_machine="armhf"
+elif [ "$(uname -m)" = "386" ] || [ "$(uname -m)" = "i386" ] || [ "$(uname -m)" = "i686" ] || [ "$(uname -m)" = "x86" ]; then
+    hardware_machine="i386"
+elif [ "$(uname -m)" = "amd64" ] || [ "$(uname -m)" = "x86_64" ]; then
+    hardware_machine="amd64"
+else
+    echo "Unsupported machine hardware: $(uname -m)"
+    exit 1
+fi
+
+check_env=''
+if [ $# -ge 1 ] && [ "env" = "$1" ]; then
+    check_env=true
+fi
+
+if [ "" = "$check_env" ]; then
+    : # do nothing
+elif [ -e /data/adb/modules/chroot-distro ]; then
+    echo "Script: $0"
+    hash=$(md5sum "$0" | cut -d " " -f1)
+    if cmp --silent "$0" /data/adb/modules/chroot-distro/system/bin/chroot-distro; then
+        (
+            # shellcheck disable=SC1091
+            . /data/adb/modules/chroot-distro/module.prop && true
+            echo "Version: ${version:-'Unknown'} (${versionCode:-'??'}), md5 hash: $hash"
+        )
+    else
+        echo "Not matching installed version, md5 hash: $hash"
+    fi
+else
+    echo "Script: $0"
+    echo "Unknown version, md5 hash: $(md5sum "$0" | cut -d " " -f1)"
+fi
+
+if [ "" != "$check_env" ]; then
+    echo "Toybox version: $(toybox --version)"
+fi
+
 busyboxpath="$(command -v busybox 2> /dev/null)"
 # shellcheck disable=SC2181
 # need both ouput and error code thus needs indirect error checking
@@ -20,6 +61,9 @@ if [ $? -ne 0 ]; then
     busyboxpath=''
     if [ -e /data/adb ]; then
         # try harder... thanks @osm0osis
+        if [ "" != "$check_env" ]; then
+            echo 'Checking for hidden Busyboxes'
+        fi
         for possiblepath in /data/adb/modules/busybox-ndk/system/*/busybox /data/adb/magisk/busybox /data/adb/ksu/bin/busybox /data/adb/ap/bin/busybox; do
             if [ "" = "$busyboxpath" ] && [ -f "$possiblepath" ]; then
                 busyboxpath="$possiblepath"
@@ -31,6 +75,12 @@ if [ $? -ne 0 ]; then
         exit 1
     fi
 fi
+
+if [ "" != "$check_env" ]; then
+    echo "Busybox => '$busyboxpath'"
+    echo "Busybox version: $($busyboxpath | head -n1)"
+fi
+
 unsupported_busybox=''
 case "$busyboxpath" in
     /bin/*) ;; # assume that it is ok (either old android, or linux), nothing to do
@@ -38,6 +88,10 @@ case "$busyboxpath" in
         ndk_path=/system/xbin/busybox
         if [ "$busyboxpath" != "$ndk_path" ] && [ -e "$ndk_path" ]; then
             # force use of Busybox for Android NDK in the case there is conflicting versions
+            if [ "" != "$check_env" ]; then
+                echo "Forcing Busybox path from '$busyboxpath' to '$ndk_path'"
+                echo "Forced Busybox version: $($ndk_path | head -n1)"
+            fi
             busyboxpath="$ndk_path"
         fi
     ;;
@@ -52,6 +106,47 @@ case "$busyboxpath" in
     ;;
 esac
 
+if [ "" != "$check_env" ]; then
+    if [ ! -e /data/adb ]; then
+        echo 'Could not determine the type of root solution installed'
+    elif [ -e /data/adb/magisk ]; then
+        case "$hardware_machine" in
+            *64) magisk_version=$(/data/adb/magisk/magisk64 -v) ;;
+            *) magisk_version=$(/data/adb/magisk/magisk32 -v) ;;
+        esac
+        echo "Magisk installed ($magisk_version)"
+    elif [ -e /data/adb/ksu ]; then
+        # would be nice if the version information could be provided, patches welcome
+        echo 'KernelSU installed (version not known)'
+    elif [ -e /data/adb/ap ]; then
+        # would be nice if the version information could be provided, patches welcome
+        echo 'APatch installed (version not known)'
+    else
+        echo 'Unknown root solution, possible candidates:'
+        for candidate in /data/adb/*; do
+            if [ -d "$candidate" ]; then
+                dirname=$(basename "$candidate")
+                case "$dirname" in
+                    modules) ;; # not interested
+                    post-fs-data.d) ;; # not interested
+                    service.d) ;; # not interested
+                    *) echo "$dirname" ;;
+                esac
+            fi
+        done
+        echo 'list end'
+    fi
+    # don't want machine name, otherwise -a would be easiest
+    if [ "unknown" != "$(uname -p)" ]; then
+        uname -s -r -v -m -p -i -o
+    else
+        uname -s -r -v -m -o
+    fi
+    echo "PATH=$PATH"
+    # check run successfully, bail out
+    exit 0
+fi
+
 # ensure that the expected version of busybox is used
 busybox() { "$busyboxpath" "$@"; }
 
@@ -62,6 +157,7 @@ getopt --test > /dev/null && true
 if [ $? -ne 4 ]; then
     # shellcheck disable=SC2016
     echo 'I'\''m sorry, `getopt --test` failed in this environment.'
+    echo "Run '$script env' for extra information"
     exit 1
 fi
 
@@ -74,6 +170,7 @@ tar() { busybox tar "$@"; }
 tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
 if [ $? -eq 1 ]; then
     echo 'Your Busybox tar does not support xz compression. Update your busybox!'
+    echo "Run '$script env' for extra information"
     exit 1
 fi
 
@@ -90,19 +187,6 @@ if [ ! -d "$chroot_distro_path/.backup/" ]; then
     mkdir -p $chroot_distro_path/.backup/
 fi
 
-if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
-    hardware_machine="arm64"
-elif [ "$(uname -m)" = "arm" ] || [ "$(uname -m)" = "armel" ] || [ "$(uname -m)" = "armhf" ] || [ "$(uname -m)" = "armhfp" ] || [ "$(uname -m)" = "armv7" ] || [ "$(uname -m)" = "armv7l" ] || [ "$(uname -m)" = "armv7a" ] || [ "$(uname -m)" = "armv8l" ]; then
-    hardware_machine="armhf"
-elif [ "$(uname -m)" = "386" ] || [ "$(uname -m)" = "i386" ] || [ "$(uname -m)" = "i686" ] || [ "$(uname -m)" = "x86" ]; then
-    hardware_machine="i386"
-elif [ "$(uname -m)" = "amd64" ] || [ "$(uname -m)" = "x86_64" ]; then
-    hardware_machine="amd64"
-else
-    echo "Unsupported machine hardware: $(uname -m)"
-    exit 1
-fi
-
 chroot_distro_warn_if_unsupported_busybox() {
     if [ "" != "$unsupported_busybox" ]; then
         echo "Warning: You are using Magisk/KernelSU/APatch without Busybox Android NDK installed."
@@ -116,6 +200,7 @@ chroot_distro_help() {
 usage :
 
 $script help - for more information
+$script env - output debug information about environment
 $script list - list of available linux distributions
 
 $script download <distro> - download rootfs

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -77,15 +77,18 @@ if [ $? -ne 0 ]; then
             fi
         done;
     fi
-    if [ "" = "$busyboxpath" ]; then
+    if [ "" = "$check_env" ] && [ "" = "$busyboxpath" ]; then
         echo "busybox not found, install busybox for Android NDK and try again"
+        echo "Run '$script env' for extra information"
         exit 1
     fi
 fi
 
 if [ "" != "$check_env" ]; then
     echo "busybox => '$busyboxpath'"
-    echo "Busybox version: $($busyboxpath | head -n1)"
+    if [ "" != "$busyboxpath" ]; then
+        echo "Busybox version: $($busyboxpath | head -n1)"
+    fi
 fi
 
 unsupported_busybox=''
@@ -110,13 +113,14 @@ case "$busyboxpath" in
     *)
         if [ "" = "$check_env" ]; then
             echo "busybox not found from the expected path, ensure that busybox for Android NDK has been installed and try again"
+            echo "Run '$script env' for extra information"
             exit 1
         fi
     ;;
 esac
 
 busyboxdir="$(dirname "$busyboxpath")"
-if [ "/system/bin" != "$busyboxdir" ] && [ -e "$busyboxdir"/chroot ]; then
+if [ "" != "$busyboxpath" ] && [ "/system/bin" != "$busyboxdir" ] && [ -e "$busyboxdir"/chroot ]; then
     # Use chroot from the expected Busybox, but not the toybox version
     chrootpath="$(dirname "$busyboxpath")"/chroot
 elif [ -e /system/xbin/chroot ]; then
@@ -141,7 +145,14 @@ fi
 busybox() { "$busyboxpath" "$@"; }
 
 # toybox does not support -p
-uname() { busybox uname "$@"; }
+uname() {
+    if [ "" != "$busyboxpath" ]; then
+        busybox uname "$@";
+    else
+        # fall back to defaults to ensure at least some output
+        uname -a
+    fi
+}
 
 # ensure that busybox version of getopt is used
 getopt() { busybox getopt "$@"; }

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -44,7 +44,7 @@ fi
 non_existent_file=$(mktemp -u)
 
 tar_supports_xz=true
-tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
+busybox tar -t -J -f "$non_existent_file.tar.xz" 1>/dev/null 2>&1
 if [ $? -eq 1 ]; then
     tar_supports_xz=''
 fi
@@ -883,9 +883,9 @@ chroot_distro_install() {
     if [ "." = "$rootdir" ]; then
         mkdir "$distro_path"
         if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$archive_path" | tar -x -C "$distro_path/"
+            xz -cd "$archive_path" | busybox tar -x -C "$distro_path/"
         else
-            tar -xf "$archive_path" -C "$distro_path/"
+            busybox tar -xf "$archive_path" -C "$distro_path/"
         fi
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -894,9 +894,9 @@ chroot_distro_install() {
         fi
     else
         if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$archive_path" | tar -x -C "$chroot_distro_path/"
+            xz -cd "$archive_path" | busybox tar -x -C "$chroot_distro_path/"
         else
-            tar -xf "$archive_path" -C "$chroot_distro_path/"
+            busybox tar -xf "$archive_path" -C "$chroot_distro_path/"
         fi
         tar_status=$?
         if [ $tar_status -ne 0 ] && [ ! -e "$chroot_distro_path/$rootdir" ]; then
@@ -996,9 +996,9 @@ chroot_distro_backup() {
             cd "$chroot_distro_path" || exit 1;
             if [ "" = "$tar_supports_xz" ]; then
                 # use gzip compression as xz is not supported
-                tar -czvf "$backup_path" "$distro"
+                busybox tar -czvf "$backup_path" "$distro"
             else
-                tar -cvf "$backup_path" "$distro"
+                busybox tar -cvf "$backup_path" "$distro"
             fi
         )
         # shellcheck disable=SC2181
@@ -1013,13 +1013,13 @@ chroot_distro_backup() {
                 *.tar.xz) {
                     if [ "" = "$tar_supports_xz" ]; then
                         # use gzip compression as xz is not supported
-                        tar -czvf "$2" "$distro"
+                        busybox tar -czvf "$2" "$distro"
                     else
-                        tar -cJvf "$2" "$distro"
+                        busybox tar -cJvf "$2" "$distro"
                     fi
                 } ;;
                 # rely on compression autodetection
-                *) tar -cvf "$2" "$distro" ;;
+                *) busybox tar -cvf "$2" "$distro" ;;
             esac;
         )
         # shellcheck disable=SC2181
@@ -1039,9 +1039,9 @@ chroot_distro_find_archive_common_path() {
     fi
     if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
         # archive uses xz but tar does not support it natively
-        paths_to_check="$(xz -cd "$archive_path" | tar -t 2>/dev/null)"
+        paths_to_check="$(xz -cd "$archive_path" | busybox tar -t 2>/dev/null)"
     else
-        paths_to_check="$(tar -tf "$archive_path" 2>/dev/null)"
+        paths_to_check="$(busybox tar -tf "$archive_path" 2>/dev/null)"
     fi
 
     i=1
@@ -1120,9 +1120,9 @@ chroot_distro_restore() {
         # backup has relative path, restoring is not a problem
         mkdir "$distro_path"
         if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-            xz -cd "$backup_path" | tar -x -C "$distro_path/"
+            xz -cd "$backup_path" | busybox tar -x -C "$distro_path/"
         else
-            tar -xf "$backup_path" -C "$distro_path/"
+            busybox tar -xf "$backup_path" -C "$distro_path/"
         fi
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1137,9 +1137,9 @@ chroot_distro_restore() {
         (
             cd /
             if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-                xz -cd "$backup_path" | tar -x
+                xz -cd "$backup_path" | busybox tar -x
             else
-                tar -xf "$backup_path"
+                busybox tar -xf "$backup_path"
             fi
         )
         # shellcheck disable=SC2181
@@ -1163,9 +1163,9 @@ chroot_distro_restore() {
         (
             cd "$chroot_distro_path" || exit 1;
             if [ "xz" = "$archive_type" ] && [ "" = "$tar_supports_xz" ]; then
-                xz -cd "$backup_path" | tar -x
+                xz -cd "$backup_path" | busybox tar -x
             else
-                tar -xf "$backup_path"
+                busybox tar -xf "$backup_path"
             fi
         )
         # shellcheck disable=SC2181

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -180,7 +180,7 @@ fi
 non_existent_file=$(mktemp -u)
 
 tar_output=$(tar -t -J -f "$non_existent_file.tar.xz" 2>&1)
-if [ "1" = $(echo "$tar_output" | grep -i -c "(invalid|unknown) option") ]; then
+if [ "1" = "$(echo "$tar_output" | grep -i -c "(invalid|unknown) option")" ]; then
     echo 'Your Busybox tar does not support xz compression. Update your busybox!'
     echo "Run '$script env' for extra information"
     exit 1

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -67,7 +67,7 @@ busyboxpath="$(command -v busybox 2> /dev/null)"
 if [ $? -ne 0 ]; then
     busyboxpath=''
     if [ -e /data/adb ]; then
-        # try harder... thanks @osm0osis
+        # try harder... -- thanks for the pointer, @osm0osis
         if [ "" != "$check_env" ]; then
             echo 'Checking for hidden Busyboxes'
         fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -115,6 +115,28 @@ case "$busyboxpath" in
     ;;
 esac
 
+busyboxdir="$(dirname "$busyboxpath")"
+if [ "/system/bin" != "$busyboxdir" ] && [ -e "$busyboxdir"/chroot ]; then
+    # Use chroot from the expected Busybox, but not the toybox version
+    chrootpath="$(dirname "$busyboxpath")"/chroot
+elif [ -e /system/xbin/chroot ]; then
+    # Use a busybox version
+    chrootpath=/system/xbin/chroot
+elif [ -e /system/bin/chroot ]; then
+    # Fall back to toybox version
+    chrootpath=/system/bin/chroot
+else
+    # don't want to use a random chroot to ensure it doesn't affect the jail
+    chrootpath=''
+fi
+unset busyboxdir
+
+if [ "" = "$check_env" ] && [ "" = "$chrootpath" ]; then
+    echo "chroot not found from the expected path, ensure that busybox for Android NDK has been installed and try again"
+    echo "Run '$script env' for extra information"
+    exit 1
+fi
+
 # ensure that the expected version of busybox is used
 busybox() { "$busyboxpath" "$@"; }
 
@@ -130,7 +152,14 @@ tar() { busybox tar "$@"; }
 # ensure that busybox version of wget is used
 wget() { busybox wget "$@"; }
 
+# ensure that correct version of chroot is used
+chroot() { "$chrootpath" "$@"; }
+
 if [ "" != "$check_env" ]; then
+    echo "chroot => '$chrootpath'"
+    if [ "" = "$chrootpath" ]; then
+        echo "chroot found in PATH (but not used) => '$(command -v chroot 2> /dev/null)'"
+    fi
     if [ ! -e /data/adb ]; then
         echo 'Could not determine the type of root solution installed'
     elif [ -e /data/adb/magisk ]; then
@@ -937,10 +966,10 @@ chroot_distro_jail() {
             unset PREFIX;
             if [ "" != "$command" ]; then
                 # shellcheck disable=SC1007
-                PATH= /system/bin/chroot "$distro_path/" "$su_command" - root -c "$command"
+                PATH= chroot "$distro_path/" "$su_command" - root -c "$command"
             else
                 # shellcheck disable=SC1007
-                PATH= /system/bin/chroot "$distro_path/" "$su_command" - root
+                PATH= chroot "$distro_path/" "$su_command" - root
             fi
         )
         return
@@ -966,9 +995,9 @@ chroot_distro_jail() {
         unset SYSTEMSERVERCLASSPATH;
         unset LD_LIBRARY_PATH;
         if [ "" != "$command" ]; then
-            SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" /system/bin/chroot "$distro_path/" /bin/sh -lc "$command"
+            SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" chroot "$distro_path/" /bin/sh -lc "$command"
         else
-            SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" /system/bin/chroot "$distro_path/" /bin/sh -l
+            SHELL=/bin/sh HOME="$JAIL_HOME" PATH="$JAIL_PATH" chroot "$distro_path/" /bin/sh -l
         fi
     )
 }


### PR DESCRIPTION
Try to find Busybox binary harder (in case of hidden Busybox), thanks @osm0sis. Also, rely on found Busybox as much as possible to ensure consistent running environment. This change makes it possible to use `chroot-distro` without separately installed Busybox NDK Magisk module. But, be aware that using `chroot-distro` without Busybox NDK Magisk module is not a supported configuration and relies on the community to report problems.

In the process fixed XZ compression handling.

Added `env` command to output debug information about the environment. This will output information about found Busybox (regardless from where it is found) and other tidbits which may help ensuring the correct versions are used and in the case of errors may help locating the source of a problem.