### PR TITLE
Unconditionally remove /dev/pts system mount point

### DIFF
--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -889,9 +889,7 @@ chroot_distro_unmount_system_points() {
     chroot_distro_unmount_system_point "$distro_path/data"
     chroot_distro_unmount_system_point "$distro_path/system"
     chroot_distro_unmount_system_point "$distro_path/sdcard"
-    if [ -f "$distro_path/dev/pts" ]; then
-        chroot_distro_unmount_system_point "$distro_path/dev/pts"
-    fi
+    chroot_distro_unmount_system_point "$distro_path/dev/pts"
     chroot_distro_unmount_system_point "$distro_path/proc"
     chroot_distro_unmount_system_point "$distro_path/sys"
     chroot_distro_unmount_system_point "$distro_path/dev"


### PR DESCRIPTION
Had a little oversight where I thought /dev/pts may be a file mount point but it is a folder mount.