### PR TITLE
Fix backup compression

### DIFF
--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1157,6 +1157,7 @@ chroot_distro_uninstall() {
 
 chroot_distro_backup() {
     distro=$1
+    custom_path=$2
     supported="alpine archlinux artix debian deepin fedora manjaro openkylin opensuse pardus ubuntu void kali parrot backbox centos centos_stream"
     if ! chroot_distro_check_if_supported "$supported" "$distro"; then
         echo "unavailable distro $distro"
@@ -1187,7 +1188,7 @@ chroot_distro_backup() {
         exit 1
     fi
 
-    if [ "$2" = "" ]; then
+    if [ "" = "$custom_path" ]; then
         backup_path="$chroot_distro_path/.backup/$1.tar.xz"
         if [ -f "$backup_path" ]; then
             echo "backup already exist, unbackup and try agin"
@@ -1195,7 +1196,7 @@ chroot_distro_backup() {
         fi
         (
             cd "$chroot_distro_path" || exit 1;
-            tar -cvf "$backup_path" "$distro"
+            tar -cvJf "$backup_path" "$distro"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1205,7 +1206,33 @@ chroot_distro_backup() {
     else
         (
             cd "$chroot_distro_path" || exit 1;
-            tar -cvf "$2" "$distro"
+            case "$custom_path" in
+                *.gz) format=gz ;;
+                *.tgz) format=gz ;;
+                *.xz) format=xz ;;
+                *.txz) format=xz ;;
+                *.bz2) format=bz2 ;;
+                *.tbz2) format=bz2 ;;
+                *.tar) format=tar ;;
+                *)
+                    echo 'Warning: Could not detect archive format, will rely on tar autodetetion'
+                    echo 'This might cause the archive being left uncompressed.'
+                    format=tar
+                ;;
+            esac
+            if [ "tar" = "$format" ]; then
+                tar -cvf "$custom_path" "$distro"
+            elif [ "gz" = "$format" ]; then
+                tar -cvzf "$custom_path" "$distro"
+            elif [ "xz" = "$format" ]; then
+                tar -cvJf "$custom_path" "$distro"
+            elif [ "bz2" = "$format" ]; then
+                tar -cvjf "$custom_path" "$distro"
+            else
+                # should hit this branch only if above switch case was updated but the branches here were forgotten to update
+                echo "Error: Unknown format!"
+                exit 5
+            fi
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1078,6 +1078,12 @@ chroot_distro_install() {
     fi
 
     common_path="$( chroot_distro_find_archive_common_path "$archive_path" )"
+    # shellcheck disable=SC2181
+    # we want both the output and error code, so need indirection
+    if [ $? -ne 0 ]; then
+        # Something went wrong with finding the archive common path
+        return $?
+    fi
     if [ "" = "$common_path" ]; then
         common_path="."
     fi
@@ -1246,7 +1252,7 @@ chroot_distro_find_archive_common_path() {
     archive_path=$1
     archive_type=${archive_type-$(chroot_distro_check_archive_file_type "$archive_path")}
     if [ "" = "$archive_type" ]; then
-        echo "Error: unsupported or corrupt archive"
+        echo "Error: unsupported or corrupt archive" >&2
         exit 5
     fi
     paths_to_check="$(tar -tf "$archive_path" 2>/dev/null)"
@@ -1312,6 +1318,12 @@ chroot_distro_restore() {
     fi
 
     common_path="$(chroot_distro_find_archive_common_path "$backup_path")"
+    # shellcheck disable=SC2181
+    # we want both the output and error code, so need indirection
+    if [ $? -ne 0 ]; then
+        # Something went wrong with finding the archive common path
+        return $?
+    fi
     if [ "" = "$common_path" ]; then
         common_path="."
     fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -821,10 +821,14 @@ chroot_distro_download() {
 chroot_distro_check_if_supported() {
     echo "$1" | tr ' ' '\n' | while read -r distro; do
         if [ "$distro" = "$2" ]; then
-            return 1
+            return 99;
         fi
     done
-    return 0
+    if [ $? -eq 99 ]; then
+        return 0;
+    else
+        return 1;
+    fi
 }
 
 chroot_distro_delete() {

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -994,6 +994,11 @@ chroot_distro_check_archive_file_type() {
         echo "xz"
         return
     fi
+    if tar -tf "$archive_path" 1>/dev/null 2>&1 ; then
+        # either it is real tar file, or something else which isn't gunzip or xz
+        echo "tar"
+        return
+    fi
 }
 
 chroot_distro_find_su() {

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1207,7 +1207,7 @@ chroot_distro_backup() {
         fi
         (
             cd "$chroot_distro_path" || exit 1;
-            tar -cvJf "$backup_path" "$distro"
+            tar -cavf "$backup_path" "$distro"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1217,33 +1217,7 @@ chroot_distro_backup() {
     else
         (
             cd "$chroot_distro_path" || exit 1;
-            case "$custom_path" in
-                *.gz) format=gz ;;
-                *.tgz) format=gz ;;
-                *.xz) format=xz ;;
-                *.txz) format=xz ;;
-                *.bz2) format=bz2 ;;
-                *.tbz2) format=bz2 ;;
-                *.tar) format=tar ;;
-                *)
-                    echo 'Warning: Could not detect archive format, will rely on tar autodetetion'
-                    echo 'This might cause the archive being left uncompressed.'
-                    format=tar
-                ;;
-            esac
-            if [ "tar" = "$format" ]; then
-                tar -cvf "$custom_path" "$distro"
-            elif [ "gz" = "$format" ]; then
-                tar -cvzf "$custom_path" "$distro"
-            elif [ "xz" = "$format" ]; then
-                tar -cvJf "$custom_path" "$distro"
-            elif [ "bz2" = "$format" ]; then
-                tar -cvjf "$custom_path" "$distro"
-            else
-                # should hit this branch only if above switch case was updated but the branches here were forgotten to update
-                echo "Error: Unknown format!"
-                exit 5
-            fi
+            tar -cavf "$custom_path" "$distro"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
By relying on autodetection for backup format tar may not use any compression at all. Force compression usage based on file extension.

Propagate errors when detecting archive common path.

Accept uncompressed tar files as backup files (and thus also uncompressed rootfs tar files, although there is none currently).

Also, fixed distro name check. I didn't realize that if piping is used then it will use a subshell.