### PR TITLE
Force unmount and unmount all mount points

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ chroot-distro install [-a|--android] <distro>
 ```
 + reinstall distro
   + By default does not mount `/data` or `/system` folder, use `-a` or `--android` to mount it
+  + By default stops reinstall if there is open files and/or active mounts within the distro. By using `-f` or `--force` will try closing any process trying to access distro rootfs, and unmount any active mount points. You should prefer running the command first without `force` option to review the processes and mounts before forcefully closing them.
 ```
-chroot-distro reinstall [-a|--android] <distro>
+chroot-distro reinstall [-a|--android] [-f|--force] <distro>
 ```
 + uninstall distro
+  + By default stops uninstall if there is open files and/or active mounts within the distro. By using `-f` or `--force` will try closing any process trying to access distro rootfs, and unmount any active mount points. You should prefer running the command first without `force` option to review the processes and mounts before forcefully closing them.
 ```
-chroot-distro uninstall <distro>
+chroot-distro uninstall [-f|--force] <distro>
 ```
 
 + backup distro

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ chroot-distro unbackup <distro>
 chroot-distro restore [-d|--default] [--force] <distro> [<path>]
 ```
 
-+ unmount system mount points
-  + By default stops if unmounting fails. By using `-f` or `--force` will try closing any process trying to access system mount point, and unmount any active mount points which prevent system mount points from unmounting. You should prefer running the command first without `force` option to review the processes and mounts before forcefully closing them.
++ unmount (system) mount points
+  + By default stops if unmounting fails. By using `-f` or `--force` will try closing any process trying to access (system) mount point, and unmount any active mount points which prevent (system) mount points from unmounting. You should prefer running the command first without `force` option to review the processes and mounts before forcefully closing them.
+  + By default unmounts only system mount points. By using `-a` or `--all` will try to unmount all found mount points be it a normal mount poit, or a loopback mount point.
 ```
-chroot-distro unmount [-f|--force] <distro>
+chroot-distro unmount [-f|--force] [-a|--all] <distro>
 ```
 
 + run command

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ chroot-distro restore [-d|--default] [--force] <distro> [<path>]
 ```
 
 + unmount system mount points
+  + By default stops if unmounting fails. By using `-f` or `--force` will try closing any process trying to access system mount point, and unmount any active mount points which prevent system mount points from unmounting. You should prefer running the command first without `force` option to review the processes and mounts before forcefully closing them.
 ```
-chroot-distro unmount <distro>
+chroot-distro unmount [-f|--force] <distro>
 ```
 
 + run command

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1363,17 +1363,19 @@ chroot_distro_backup() {
 
     # mounted volumes should be backed up outside of this script as it may not work as intended
     # (same reasons as system mount points)
-    mount_count=$(mount | grep -Fc "$distro_path")
-    loopback_count=$(losetup -a | grep -Fc "$distro_path")
-    if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ]; then
+    mounts=$(mount | grep -F "$distro_path")
+    loopbacks=$(losetup -a | grep -F "$distro_path")
+    if [ "0" != "$mounts" ] || [ "0" != "$loopbacks" ]; then
         echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
         echo
+        echo "To automatically unmount mount points mentioned below, run \`$script unmount -a $1\`"
+        echo
         echo "mount points under $distro_path:"
-        mount | grep -F "$distro_path/"
+        echo "${mounts:-Not found}"
         echo "end of mount points"
         echo
         echo "loopback devices under $distro_path:"
-        losetup -a | grep -F "$distro_path/"
+        echo "${loopbacks:-Not found}"
         echo "end of loopback devices"
         exit 1
     fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1242,6 +1242,46 @@ chroot_distro_install() {
     chroot_distro_jail "$distro_path"
 }
 
+chroot_distro_list_unmount_issues() {
+    distro_path=$1
+    command=$2
+    mode=$3
+    force=$4
+    mounts=$5
+    loopbacks=$6
+    open_files=$7
+
+    unset maybe_more
+    if [ "all" != "$mode" ]; then
+        maybe_more=true
+    fi
+    # note: if there is still system mount points mounted without a valid reason, please create a bug report so that it can be investigated
+    echo 'distro is potentially running - if needed shutdown the distro, and unmount mounted folders'
+    echo
+    if [ "yes" != "$force" ]; then
+        echo "You can try running $command again with -f(--force) option to automatically close/unmount files/folders mentioned below."
+        echo 'Please note, that using --force option may close more programs than intended, so use it with care.'
+    fi
+    echo
+    echo "open files under $distro_path${maybe_more+ (which affects unmounting, there may be more)}:"
+    if [ "" = "$lsofpath" ]; then
+        echo "Warning: supported lsof not found, run \`lsof | grep -F '$distro_path/'\` manually"
+    fi
+    echo "${open_files:-Not found}"
+    echo "end of open files"
+    echo
+    echo "mount points under $distro_path${maybe_more+ (which affects unmounting, there may be more)}:"
+    echo "${mounts:-Not found}"
+    echo "end of mount points"
+    echo
+    echo "loopback devices under $distro_path${maybe_more+ (which affects unmounting, there may be more)}:"
+    echo "${loopbacks:-Not found}"
+    echo "end of loopback devices"
+    echo
+    echo "If there is no open files, mount points ${maybe_more-(outside of system mount points) }or loopback devices,"
+    echo "then check for anonymous inodes and inotify watches"
+}
+
 chroot_distro_uninstall() {
     supported="alpine archlinux artix debian deepin fedora manjaro openkylin opensuse pardus ubuntu void kali parrot backbox centos centos_stream"
     if ! chroot_distro_check_if_supported "$supported" "$1"; then
@@ -1251,6 +1291,7 @@ chroot_distro_uninstall() {
 
     distro_path="$chroot_distro_path/$1"
     force=$2
+    command=$3
 
     if [ -d "$distro_path" ]; then
         if [ "yes" = "$force" ]; then
@@ -1270,36 +1311,7 @@ chroot_distro_uninstall() {
         loopbacks=$(losetup -a | grep -F "$distro_path")
         open_files=$(lsof | grep -F "$distro_path")
         if [ "" != "$mounts" ] || [ "" != "$loopbacks" ] || [ "" != "$open_files" ]; then
-            # note: if there is still system mount points mounted without a valid reason, please create a bug report so that it can be investigated
-            echo 'distro is potentially running - if needed shutdown the distro, and unmount mounted folders'
-            echo
-            if [ "yes" != "$force" ]; then
-                echo 'You can try running uninstall/reinstall again with -f(--force) option to automatically close/unmount files/folders mentioned below.'
-                echo 'Please note, that using --force option may close more programs than intended, so use it with care.'
-            fi
-            echo
-            echo "open files under $distro_path:"
-            if [ "" = "$lsofpath" ]; then
-                echo "Warning: supported lsof not found, run \`lsof | grep -F '$distro_path/'\` manually"
-            elif [ "" != "$open_files" ]; then
-                echo "$open_files"
-            fi
-            echo "end of open files"
-            echo
-            echo "mount points under $distro_path:"
-            if [ "" != "$mounts" ]; then
-                echo "$mounts"
-            fi
-            echo "end of mount points"
-            echo
-            echo "loopback devices under $distro_path:"
-            if [ "" != "$loopbacks" ]; then
-                echo "$loopbacks"
-            fi
-            echo "end of loopback devices"
-            echo
-            echo "If there is no open files, mount points (outside of system mount points) or loopback devices,"
-            echo "then check for anonymous inodes and inotify watches"
+            chroot_distro_list_unmount_issues "$distro_path" "$command" 'all' "$force" "$mounts" "$loopbacks" "$open_files"
             exit 1
         fi
 
@@ -1565,35 +1577,7 @@ chroot_distro_unmount() {
     loopbacks=$(losetup -a | chroot_distro_output_system_mount_point_paths "$distro_path")
     open_files=$(lsof | chroot_distro_output_system_mount_point_paths "$distro_path")
     if [ "" != "$mounts" ] || [ "" != "$loopbacks" ] || [ "" != "$open_files" ] || chroot_distro_check_if_system_points_mounted "$distro_path"; then
-        # note: if there is still system mount points mounted without a valid reason, please create a bug report so that it can be investigated
-        echo 'distro is potentially running - if needed shutdown the distro, and unmount mounted folders'
-        echo
-        if [ "yes" != "$force" ]; then
-            echo 'You can try running unmount again with -f(--force) option to automatically close/unmount files/folders mentioned below.'
-            echo 'Please note, that using --force option may close more programs than intended, so use it with care.'
-        fi
-        echo
-        echo "open files under $distro_path (which affects unmounting, there may be more):"
-        if [ "" = "$lsofpath" ]; then
-            echo "Warning: supported lsof not found, run \`lsof | grep -F '$distro_path/'\` manually"
-        elif [ "" != "$open_files" ]; then
-            echo "$open_files"
-        fi
-        echo "end of open files"
-        echo
-        echo "mount points under $distro_path: (which affects unmounting, there may be more)"
-        if [ "" != "$mounts" ]; then
-            echo "$mounts"
-        fi
-        echo "end of mount points"
-        echo
-        echo "loopback devices under $distro_path: (which affects unmounting, there may be more)"
-        if [ "" != "$loopbacks" ]; then
-            echo "$loopbacks"
-        fi
-        echo "end of loopback devices"
-        echo
-        echo "If there is no open files, mount points or loopback devices, then check for anonymous inodes and inotify watches"
+        chroot_distro_list_unmount_issues "$distro_path" 'unmount' 'system' "$force" "$mounts" "$loopbacks" "$open_files"
         exit 1
     fi
 }
@@ -1796,7 +1780,7 @@ elif [ "$command" = "uninstall" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
-    chroot_distro_uninstall "$1" "$force"
+    chroot_distro_uninstall "$1" "$force" "$command"
 elif [ "$command" = "reinstall" ]; then
     OPTS=af LONGOPTS=android,force
     PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
@@ -1828,7 +1812,7 @@ elif [ "$command" = "reinstall" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
-    chroot_distro_uninstall "$1" "$force"
+    chroot_distro_uninstall "$1" "$force" "$command"
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "backup" ]; then
     PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -902,6 +902,21 @@ chroot_distro_unmount_system_point() {
     fi
     if ! umount "$mount_point"; then
         echo "could not unmount $mount_point, distro is potentially running - if needed shutdown the distro, and try again"
+        echo
+        echo "open files under $mount_point:"
+        # always use busybox version, to ensure consistent output
+        /system/xbin/lsof | grep -F "$mount_point"
+        echo "end of open files"
+        echo
+        echo "mount points under $mount_point:"
+        mount | grep -F "$mount_point"
+        echo "end of mount points"
+        echo
+        echo "loopback devices under $mount_point:"
+        losetup | grep -F "$mount_point"
+        echo "end of loopback devices"
+        echo
+        echo "If there is no open files, mount points or loopback devices, then check for anonymous inodes and inotify watches"
         exit 1
     fi
 }
@@ -1152,6 +1167,10 @@ chroot_distro_uninstall() {
         if [ "0" != "$mount_count" ]; then
             # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
             echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
+            echo
+            echo "mount points under $distro_path:"
+            mount | grep -F "$distro_path"
+            echo "end of mount points"
             exit 1
         fi
 
@@ -1196,6 +1215,10 @@ chroot_distro_backup() {
     mount_count=$(mount | grep -Fc "$distro_path")
     if [ "0" != "$mount_count" ]; then
         echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
+        echo
+        echo "mount points under $distro_path:"
+        mount | grep -F "$distro_path"
+        echo "end of mount points"
         exit 1
     fi
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1215,6 +1215,11 @@ chroot_distro_backup() {
         exit
     fi
 
+    open_file_count=$(lsof | grep -Fc "$distro_path")
+    if [ "0" != "$open_file_count" ]; then
+        echo "Warning: Open files detected, backup may fail (at least partially)"
+    fi
+
     # mounted volumes should be backed up outside of this script as it may not work as intended
     # (same reasons as system mount points)
     mount_count=$(mount | grep -Fc "$distro_path")

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -905,15 +905,15 @@ chroot_distro_unmount_system_point() {
         echo
         echo "open files under $mount_point:"
         # always use busybox version, to ensure consistent output
-        /system/xbin/lsof | grep -F "$mount_point"
+        /system/xbin/lsof | grep -F "$mount_point/"
         echo "end of open files"
         echo
         echo "mount points under $mount_point:"
-        mount | grep -F "$mount_point"
+        mount | grep -F "$mount_point/"
         echo "end of mount points"
         echo
         echo "loopback devices under $mount_point:"
-        losetup | grep -F "$mount_point"
+        losetup | grep -F "$mount_point/"
         echo "end of loopback devices"
         echo
         echo "If there is no open files, mount points or loopback devices, then check for anonymous inodes and inotify watches"
@@ -1170,11 +1170,11 @@ chroot_distro_uninstall() {
             echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
             echo
             echo "mount points under $distro_path:"
-            mount | grep -F "$distro_path"
+            mount | grep -F "$distro_path/"
             echo "end of mount points"
             echo
             echo "loopback devices under $distro_path:"
-            losetup | grep -F "$distro_path"
+            losetup | grep -F "$distro_path/"
             echo "end of loopback devices"
             exit 1
         fi
@@ -1223,11 +1223,11 @@ chroot_distro_backup() {
         echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
         echo
         echo "mount points under $distro_path:"
-        mount | grep -F "$distro_path"
+        mount | grep -F "$distro_path/"
         echo "end of mount points"
         echo
         echo "loopback devices under $distro_path:"
-        losetup | grep -F "$distro_path"
+        losetup | grep -F "$distro_path/"
         echo "end of loopback devices"
         exit 1
     fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -348,7 +348,10 @@ $script uninstall <distro> [-f|--force] - uninstall distro
     '-f|--force'    Force closing open files (closes the process accessing them)
                     and/or unmounting active mounts. Use with care.
 
-$script unmount <distro> - unmount system mount points from distro
+$script unmount <distro> [-f|--force] - unmount system mount points from distro
+    '-f|--force'    Force closing open files (closes the process accessing them)
+                    and/or unmounting active mounts which prevents system mount points
+                    from unmounting. Use with care.
 
 $script backup <distro> [<path>] - backup distro
     <path>          Custom path for backup location
@@ -951,6 +954,7 @@ chroot_distro_mount_system_points() {
 
 chroot_distro_unmount_system_point() {
     mount_point="$1"
+    force="$2"
     if [ ! -e "$mount_point" ]; then
         # nothing to do, mount point missing
         return
@@ -958,6 +962,18 @@ chroot_distro_unmount_system_point() {
     if ! mountpoint -q "$mount_point"; then
         # nothing to do, already unmounted
         return
+    fi
+    if [ "yes" = "$force" ]; then
+        # first try to kill all processes before trying to unmount anything
+        # note: close from earlier to later processes to ensure that no new worker processes are created during killing
+        chroot_distro_find_processes_with_open_files "$mount_point/" | xargs -I {} kill {} > /dev/null 2>&1
+        # before normal unmounts, go through all loopback devices
+        # note: in reverse order in case there is loopback mount from inside the loopback mount (quite contrived case but just in case...)
+        chroot_distro_find_all_loopback_mount_points "$mount_point/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
+        # try to unmount everything found
+        # note: using reverse sort to ensure that mounts residing deeper in the file system will be unmmounted first
+        chroot_distro_find_all_mount_points "$mount_point/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
+        # then hope for the best...
     fi
     if ! umount "$mount_point"; then
         echo "could not unmount $mount_point, distro is potentially running - if needed shutdown the distro, and try again"
@@ -985,17 +1001,18 @@ chroot_distro_unmount_system_point() {
 
 chroot_distro_unmount_system_points() {
     distro_path="$1"
+    force="$2"
     for file in "/storage"/*; do
         # no need for separator as separator already comes from file variable itself
-        chroot_distro_unmount_system_point "$distro_path$file"
+        chroot_distro_unmount_system_point "$distro_path$file" "$force"
     done
-    chroot_distro_unmount_system_point "$distro_path/data"
-    chroot_distro_unmount_system_point "$distro_path/system"
-    chroot_distro_unmount_system_point "$distro_path/sdcard"
-    chroot_distro_unmount_system_point "$distro_path/dev/pts"
-    chroot_distro_unmount_system_point "$distro_path/proc"
-    chroot_distro_unmount_system_point "$distro_path/sys"
-    chroot_distro_unmount_system_point "$distro_path/dev"
+    chroot_distro_unmount_system_point "$distro_path/data" "$force"
+    chroot_distro_unmount_system_point "$distro_path/system" "$force"
+    chroot_distro_unmount_system_point "$distro_path/sdcard" "$force"
+    chroot_distro_unmount_system_point "$distro_path/dev/pts" "$force"
+    chroot_distro_unmount_system_point "$distro_path/proc" "$force"
+    chroot_distro_unmount_system_point "$distro_path/sys" "$force"
+    chroot_distro_unmount_system_point "$distro_path/dev" "$force"
 }
 
 chroot_distro_check_if_system_point_mounted() {
@@ -1238,7 +1255,7 @@ chroot_distro_uninstall() {
             chroot_distro_find_all_mount_points "$distro_path/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
             # then hope for the best...
         fi
-        chroot_distro_unmount_system_points "$distro_path"
+        chroot_distro_unmount_system_points "$distro_path" no
         mount_count=$(mount | grep -Fc "$distro_path")
         loopback_count=$(losetup -a | grep -Fc "$distro_path")
         open_file_count=$(lsof | grep -Fc "$distro_path")
@@ -1511,19 +1528,21 @@ chroot_distro_restore() {
 }
 
 chroot_distro_unmount() {
+    distro="$1"
+    force="$2"
     supported="alpine archlinux artix debian deepin fedora manjaro openkylin opensuse pardus ubuntu void kali parrot backbox centos centos_stream"
-    if ! chroot_distro_check_if_supported "$supported" "$1"; then
-        echo "unavailable distro $1"
+    if ! chroot_distro_check_if_supported "$supported" "$distro"; then
+        echo "unavailable distro $distro"
         exit 1
     fi
 
-    distro_path="$chroot_distro_path/$1"
+    distro_path="$chroot_distro_path/$distro"
     if [ ! -d "$distro_path" ]; then
-        echo "$1 not installed"
+        echo "$distro not installed"
         exit 1
     fi
 
-    chroot_distro_unmount_system_points "$distro_path"
+    chroot_distro_unmount_system_points "$distro_path" "$force"
 }
 
 chroot_distro_command() {
@@ -1877,10 +1896,15 @@ elif [ "$command" = "login" ]; then
     fi
     chroot_distro_login "$1"
 elif [ "$command" = "unmount" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=f --longoptions=force --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
+    force=no
     while true; do
         case "$1" in
+            -f|--force)
+                force=yes
+                shift
+                ;;
             --)
                 shift
                 break
@@ -1896,7 +1920,7 @@ elif [ "$command" = "unmount" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
-    chroot_distro_unmount "$1"
+    chroot_distro_unmount "$1" "$force"
 else
     chroot_distro_invalid_parameters "invalid command $command"
 fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1164,13 +1164,18 @@ chroot_distro_uninstall() {
     if [ -d "$distro_path" ]; then
         chroot_distro_unmount_system_points "$distro_path"
         mount_count=$(mount | grep -Fc "$distro_path")
-        if [ "0" != "$mount_count" ]; then
+        loopback_count=$(losetup | grep -Fc "$distro_path")
+        if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ]; then
             # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
             echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
             echo
             echo "mount points under $distro_path:"
             mount | grep -F "$distro_path"
             echo "end of mount points"
+            echo
+            echo "loopback devices under $distro_path:"
+            losetup | grep -F "$distro_path"
+            echo "end of loopback devices"
             exit 1
         fi
 
@@ -1213,12 +1218,17 @@ chroot_distro_backup() {
     # mounted volumes should be backed up outside of this script as it may not work as intended
     # (same reasons as system mount points)
     mount_count=$(mount | grep -Fc "$distro_path")
-    if [ "0" != "$mount_count" ]; then
+    loopback_count=$(losetup | grep -Fc "$distro_path")
+    if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ]; then
         echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
         echo
         echo "mount points under $distro_path:"
         mount | grep -F "$distro_path"
         echo "end of mount points"
+        echo
+        echo "loopback devices under $distro_path:"
+        losetup | grep -F "$distro_path"
+        echo "end of loopback devices"
         exit 1
     fi
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -153,6 +153,23 @@ if [ "" = "$check_env" ] && [ "" = "$chrootpath" ]; then
     exit 1
 fi
 
+busyboxlsof=''
+if [ "" != "$busyboxpath" ] && "$busyboxpath" lsof > /dev/null 2>&1; then
+    # prefer the version provided by the found busybox binary
+    busyboxlsof=true
+    lsofpath='busybox lsof'
+elif [ -e /system/xbin/lsof ]; then
+    # busybox version
+    lsofpath=/system/xbin/lsof
+elif [ -e /system/bin/lsof ]; then
+    # toybox version
+    lsofpath=/system/bin/lsof
+else
+    # don't want to use random lsof as it may not work
+    # in this case user has to manually run the command
+    lsofpath=''
+fi
+
 # ensure that the expected version of busybox is used
 busybox() { "$busyboxpath" "$@"; }
 
@@ -178,10 +195,25 @@ wget() { busybox wget "$@"; }
 # ensure that correct version of chroot is used
 chroot() { "$chrootpath" "$@"; }
 
+lsof() {
+    if [ "" != "$busyboxlsof" ]; then
+        busybox lsof
+    elif [ "" = "$lsofpath" ]; then
+        # lsof is optional, no output
+        :
+    else
+        "$lsofpath";
+    fi
+}
+
 if [ "" != "$check_env" ]; then
     echo "chroot => '$chrootpath'"
     if [ "" = "$chrootpath" ]; then
         echo "chroot found in PATH (but not used) => '$(command -v chroot 2> /dev/null)'"
+    fi
+    echo "lsof => '$lsofpath'"
+    if [ "" = "$lsofpath" ]; then
+        echo "lsof found in PATH (but not used) => '$(command -v lsof 2> /dev/null)'"
     fi
     if [ ! -e /data/adb ]; then
         echo 'Could not determine the type of root solution installed'
@@ -904,8 +936,11 @@ chroot_distro_unmount_system_point() {
         echo "could not unmount $mount_point, distro is potentially running - if needed shutdown the distro, and try again"
         echo
         echo "open files under $mount_point:"
-        # always use busybox version, to ensure consistent output
-        /system/xbin/lsof | grep -F "$mount_point/"
+        if [ "" != "$lsofpath" ]; then
+            lsof | grep -F "$mount_point/"
+        else
+            echo "Warning: supported lsof not found, run \`lsof | grep -F '$mount_point/'\` manually"
+        fi
         echo "end of open files"
         echo
         echo "mount points under $mount_point:"
@@ -1171,8 +1206,11 @@ chroot_distro_uninstall() {
             echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
             echo
             echo "open files under $distro_path:"
-            # always use busybox version, to ensure consistent output
-            /system/xbin/lsof | grep -F "$distro_path/"
+            if [ "" != "$lsofpath" ]; then
+                lsof | grep -F "$distro_path/"
+            else
+                echo "Warning: supported lsof not found, run \`lsof | grep -F '$distro_path/'\` manually"
+            fi
             echo "end of open files"
             echo
             echo "mount points under $distro_path:"
@@ -1222,7 +1260,10 @@ chroot_distro_backup() {
     fi
 
     open_file_count=$(lsof | grep -Fc "$distro_path")
-    if [ "0" != "$open_file_count" ]; then
+    if [ "" = "$lsofpath" ]; then
+        echo "Warning: supported lsof not found, open files and/or programs currently running in jail will not be found."
+        echo "In the case of errors run \`lsof | grep -F '$distro_path/'\` manually"
+    elif [ "0" != "$open_file_count" ]; then
         echo "Warning: Open files detected, backup may fail (at least partially)"
     fi
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -909,6 +909,36 @@ chroot_distro_delete() {
     fi
 }
 
+chroot_distro_output_system_mount_point_paths() {
+    distro_path="$1"
+    storage_paths=$(
+        for file in "/storage"/*; do
+            echo "$distro_path$file"
+        done)
+    while read -r path_to_test; do
+        case "$path_to_test" in
+            *"$distro_path/data/"*) echo "$path_to_test" ;;
+            *"$distro_path/system/"*) echo "$path_to_test" ;;
+            *"$distro_path/sdcard/"*) echo "$path_to_test" ;;
+            *"$distro_path/dev/pts/"*) echo "$path_to_test" ;;
+            *"$distro_path/proc/"*) echo "$path_to_test" ;;
+            *"$distro_path/sys/"*) echo "$path_to_test" ;;
+            *"$distro_path/dev/"*) echo "$path_to_test" ;;
+            *)
+                # storage check could have been just one line like the above ones but wanted to have only
+                # the cases which prevents the unmount visible
+                echo "$storage_paths" | while read -r storage_path; do
+                    case "$path_to_test" in
+                        *"$storage_path/"*) echo "$path_to_test" ;;
+                        # everything else, ignore
+                        *) ;;
+                    esac
+                done
+            ;;
+        esac
+    done
+}
+
 chroot_distro_mount_system_point() {
     path_to_mount="$1"
     mount_point="$2"
@@ -975,28 +1005,8 @@ chroot_distro_unmount_system_point() {
         chroot_distro_find_all_mount_points "$mount_point/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
         # then hope for the best...
     fi
-    if ! umount "$mount_point"; then
-        echo "could not unmount $mount_point, distro is potentially running - if needed shutdown the distro, and try again"
-        echo
-        echo "open files under $mount_point:"
-        if [ "" != "$lsofpath" ]; then
-            lsof | grep -F "$mount_point/"
-        else
-            echo "Warning: supported lsof not found, run \`lsof | grep -F '$mount_point/'\` manually"
-        fi
-        echo "end of open files"
-        echo
-        echo "mount points under $mount_point:"
-        mount | grep -F "$mount_point/"
-        echo "end of mount points"
-        echo
-        echo "loopback devices under $mount_point:"
-        losetup -a | grep -F "$mount_point/"
-        echo "end of loopback devices"
-        echo
-        echo "If there is no open files, mount points or loopback devices, then check for anonymous inodes and inotify watches"
-        exit 1
-    fi
+    # no need to check for the success as the caller will take care of that
+    umount "$mount_point"
 }
 
 chroot_distro_unmount_system_points() {
@@ -1551,6 +1561,41 @@ chroot_distro_unmount() {
     fi
 
     chroot_distro_unmount_system_points "$distro_path" "$force"
+    mounts=$(mount | chroot_distro_output_system_mount_point_paths "$distro_path")
+    loopbacks=$(losetup -a | chroot_distro_output_system_mount_point_paths "$distro_path")
+    open_files=$(lsof | chroot_distro_output_system_mount_point_paths "$distro_path")
+    if [ "" != "$mounts" ] || [ "" != "$loopbacks" ] || [ "" != "$open_files" ] || chroot_distro_check_if_system_points_mounted "$distro_path"; then
+        # note: if there is still system mount points mounted without a valid reason, please create a bug report so that it can be investigated
+        echo 'distro is potentially running - if needed shutdown the distro, and unmount mounted folders'
+        echo
+        if [ "yes" != "$force" ]; then
+            echo 'You can try running unmount again with -f(--force) option to automatically close/unmount files/folders mentioned below.'
+            echo 'Please note, that using --force option may close more programs than intended, so use it with care.'
+        fi
+        echo
+        echo "open files under $distro_path (which affects unmounting, there may be more):"
+        if [ "" = "$lsofpath" ]; then
+            echo "Warning: supported lsof not found, run \`lsof | grep -F '$distro_path/'\` manually"
+        elif [ "" != "$open_files" ]; then
+            echo "$open_files"
+        fi
+        echo "end of open files"
+        echo
+        echo "mount points under $distro_path: (which affects unmounting, there may be more)"
+        if [ "" != "$mounts" ]; then
+            echo "$mounts"
+        fi
+        echo "end of mount points"
+        echo
+        echo "loopback devices under $distro_path: (which affects unmounting, there may be more)"
+        if [ "" != "$loopbacks" ]; then
+            echo "$loopbacks"
+        fi
+        echo "end of loopback devices"
+        echo
+        echo "If there is no open files, mount points or loopback devices, then check for anonymous inodes and inotify watches"
+        exit 1
+    fi
 }
 
 chroot_distro_command() {

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -348,10 +348,12 @@ $script uninstall <distro> [-f|--force] - uninstall distro
     '-f|--force'    Force closing open files (closes the process accessing them)
                     and/or unmounting active mounts. Use with care.
 
-$script unmount <distro> [-f|--force] - unmount system mount points from distro
+$script unmount <distro> [-f|--force] [-a|--all] - unmount (system) mount points from distro
     '-f|--force'    Force closing open files (closes the process accessing them)
-                    and/or unmounting active mounts which prevents system mount points
+                    and/or unmounting active mounts which prevents (system) mount points
                     from unmounting. Use with care.
+    '-a|--all'      Instead of unmounting only system mount points, will try to unmount
+                    all found mount points, be it a normal mount point or a loopback mount point.
 
 $script backup <distro> [<path>] - backup distro
     <path>          Custom path for backup location
@@ -1560,6 +1562,7 @@ chroot_distro_restore() {
 chroot_distro_unmount() {
     distro="$1"
     force="$2"
+    all="$3"
     supported="alpine archlinux artix debian deepin fedora manjaro openkylin opensuse pardus ubuntu void kali parrot backbox centos centos_stream"
     if ! chroot_distro_check_if_supported "$supported" "$distro"; then
         echo "unavailable distro $distro"
@@ -1572,12 +1575,39 @@ chroot_distro_unmount() {
         exit 1
     fi
 
-    chroot_distro_unmount_system_points "$distro_path" "$force"
-    mounts=$(mount | chroot_distro_output_system_mount_point_paths "$distro_path")
-    loopbacks=$(losetup -a | chroot_distro_output_system_mount_point_paths "$distro_path")
-    open_files=$(lsof | chroot_distro_output_system_mount_point_paths "$distro_path")
-    if [ "" != "$mounts" ] || [ "" != "$loopbacks" ] || [ "" != "$open_files" ] || chroot_distro_check_if_system_points_mounted "$distro_path"; then
-        chroot_distro_list_unmount_issues "$distro_path" 'unmount' 'system' "$force" "$mounts" "$loopbacks" "$open_files"
+    if [ "yes" = "$all" ]; then
+        if [ "yes" = "$force" ]; then
+            # first try to kill all processes before trying to unmount anything
+            # note: close from earlier to later processes to ensure that no new worker processes are created during killing
+            chroot_distro_find_processes_with_open_files "$distro_path/" | xargs -I {} kill {} > /dev/null 2>&1
+        fi
+        # before normal unmounts, go through all loopback devices
+        # note: in reverse order in case there is loopback mount from inside the loopback mount (quite contrived case but just in case...)
+        chroot_distro_find_all_loopback_mount_points "$distro_path/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
+        # try to unmount everything found
+        # note: using reverse sort to ensure that mounts residing deeper in the file system will be unmmounted first
+        chroot_distro_find_all_mount_points "$distro_path/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
+    else
+        chroot_distro_unmount_system_points "$distro_path" "$force"
+    fi
+
+    if [ "yes" = "$all" ]; then
+        mounts=$(mount | grep -F "$distro_path")
+        loopbacks=$(losetup -a | grep -F "$distro_path")
+        open_files=$(lsof | grep -F "$distro_path")
+        # as all mount points are being unmounted, no need to test for system mount points separately
+        system_mount_points_mounted=1
+        mode=all
+    else
+        mounts=$(mount | chroot_distro_output_system_mount_point_paths "$distro_path")
+        loopbacks=$(losetup -a | chroot_distro_output_system_mount_point_paths "$distro_path")
+        open_files=$(lsof | chroot_distro_output_system_mount_point_paths "$distro_path")
+        chroot_distro_check_if_system_points_mounted "$distro_path"
+        system_mount_points_mounted=$?
+        mode=system
+    fi
+    if [ "" != "$mounts" ] || [ "" != "$loopbacks" ] || [ "" != "$open_files" ] || [ "0" = "$system_mount_points_mounted" ]; then
+        chroot_distro_list_unmount_issues "$distro_path" 'unmount' "$mode" "$force" "$mounts" "$loopbacks" "$open_files"
         exit 1
     fi
 }
@@ -1933,13 +1963,18 @@ elif [ "$command" = "login" ]; then
     fi
     chroot_distro_login "$1"
 elif [ "$command" = "unmount" ]; then
-    PARSED=$(getopt --options=f --longoptions=force --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=fa --longoptions=force,all --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     force=no
+    all=no
     while true; do
         case "$1" in
             -f|--force)
                 force=yes
+                shift
+                ;;
+            -a|--all)
+                all=yes
                 shift
                 ;;
             --)
@@ -1957,7 +1992,7 @@ elif [ "$command" = "unmount" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
-    chroot_distro_unmount "$1" "$force"
+    chroot_distro_unmount "$1" "$force" "$all"
 else
     chroot_distro_invalid_parameters "invalid command $command"
 fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -948,7 +948,7 @@ chroot_distro_unmount_system_point() {
         echo "end of mount points"
         echo
         echo "loopback devices under $mount_point:"
-        losetup | grep -F "$mount_point/"
+        losetup -a | grep -F "$mount_point/"
         echo "end of loopback devices"
         echo
         echo "If there is no open files, mount points or loopback devices, then check for anonymous inodes and inotify watches"
@@ -1199,7 +1199,7 @@ chroot_distro_uninstall() {
     if [ -d "$distro_path" ]; then
         chroot_distro_unmount_system_points "$distro_path"
         mount_count=$(mount | grep -Fc "$distro_path")
-        loopback_count=$(losetup | grep -Fc "$distro_path")
+        loopback_count=$(losetup -a | grep -Fc "$distro_path")
         open_file_count=$(lsof | grep -Fc "$distro_path")
         if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ] || [ "0" != "$open_file_count" ]; then
             # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
@@ -1218,7 +1218,7 @@ chroot_distro_uninstall() {
             echo "end of mount points"
             echo
             echo "loopback devices under $distro_path:"
-            losetup | grep -F "$distro_path/"
+            losetup -a | grep -F "$distro_path/"
             echo "end of loopback devices"
             exit 1
         fi
@@ -1270,7 +1270,7 @@ chroot_distro_backup() {
     # mounted volumes should be backed up outside of this script as it may not work as intended
     # (same reasons as system mount points)
     mount_count=$(mount | grep -Fc "$distro_path")
-    loopback_count=$(losetup | grep -Fc "$distro_path")
+    loopback_count=$(losetup -a | grep -Fc "$distro_path")
     if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ]; then
         echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
         echo
@@ -1279,7 +1279,7 @@ chroot_distro_backup() {
         echo "end of mount points"
         echo
         echo "loopback devices under $distro_path:"
-        losetup | grep -F "$distro_path/"
+        losetup -a | grep -F "$distro_path/"
         echo "end of loopback devices"
         exit 1
     fi

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1256,32 +1256,40 @@ chroot_distro_uninstall() {
             # then hope for the best...
         fi
         chroot_distro_unmount_system_points "$distro_path" no
-        mount_count=$(mount | grep -Fc "$distro_path")
-        loopback_count=$(losetup -a | grep -Fc "$distro_path")
-        open_file_count=$(lsof | grep -Fc "$distro_path")
-        if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ] || [ "0" != "$open_file_count" ]; then
-            # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
+        mounts=$(mount | grep -F "$distro_path")
+        loopbacks=$(losetup -a | grep -F "$distro_path")
+        open_files=$(lsof | grep -F "$distro_path")
+        if [ "" != "$mounts" ] || [ "" != "$loopbacks" ] || [ "" != "$open_files" ]; then
+            # note: if there is still system mount points mounted without a valid reason, please create a bug report so that it can be investigated
             echo 'distro is potentially running - if needed shutdown the distro, and unmount mounted folders'
+            echo
             if [ "yes" != "$force" ]; then
                 echo 'You can try running uninstall/reinstall again with -f(--force) option to automatically close/unmount files/folders mentioned below.'
                 echo 'Please note, that using --force option may close more programs than intended, so use it with care.'
             fi
             echo
             echo "open files under $distro_path:"
-            if [ "" != "$lsofpath" ]; then
-                lsof | grep -F "$distro_path/"
-            else
+            if [ "" = "$lsofpath" ]; then
                 echo "Warning: supported lsof not found, run \`lsof | grep -F '$distro_path/'\` manually"
+            elif [ "" != "$open_files" ]; then
+                echo "$open_files"
             fi
             echo "end of open files"
             echo
             echo "mount points under $distro_path:"
-            mount | grep -F "$distro_path/"
+            if [ "" != "$mounts" ]; then
+                echo "$mounts"
+            fi
             echo "end of mount points"
             echo
             echo "loopback devices under $distro_path:"
-            losetup -a | grep -F "$distro_path/"
+            if [ "" != "$loopbacks" ]; then
+                echo "$loopbacks"
+            fi
             echo "end of loopback devices"
+            echo
+            echo "If there is no open files, mount points (outside of system mount points) or loopback devices,"
+            echo "then check for anonymous inodes and inotify watches"
             exit 1
         fi
 

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1245,7 +1245,7 @@ chroot_distro_backup() {
         fi
         (
             cd "$chroot_distro_path" || exit 1;
-            tar -cavf "$backup_path" "$distro"
+            tar -caf "$backup_path" "$distro"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
@@ -1255,7 +1255,7 @@ chroot_distro_backup() {
     else
         (
             cd "$chroot_distro_path" || exit 1;
-            tar -cavf "$custom_path" "$distro"
+            tar -caf "$custom_path" "$distro"
         )
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1148,7 +1148,7 @@ chroot_distro_uninstall() {
     distro_path="$chroot_distro_path/$1"
     if [ -d "$distro_path" ]; then
         chroot_distro_unmount_system_points "$distro_path"
-        mount_count=$(mount | grep -c "$distro_path")
+        mount_count=$(mount | grep -Fc "$distro_path")
         if [ "0" != "$mount_count" ]; then
             # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
             echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
@@ -1193,7 +1193,7 @@ chroot_distro_backup() {
 
     # mounted volumes should be backed up outside of this script as it may not work as intended
     # (same reasons as system mount points)
-    mount_count=$(mount | grep -c "$distro_path")
+    mount_count=$(mount | grep -Fc "$distro_path")
     if [ "0" != "$mount_count" ]; then
         echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
         exit 1

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1165,9 +1165,15 @@ chroot_distro_uninstall() {
         chroot_distro_unmount_system_points "$distro_path"
         mount_count=$(mount | grep -Fc "$distro_path")
         loopback_count=$(losetup | grep -Fc "$distro_path")
-        if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ]; then
+        open_file_count=$(lsof | grep -Fc "$distro_path")
+        if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ] || [ "0" != "$open_file_count" ]; then
             # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
             echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
+            echo
+            echo "open files under $distro_path:"
+            # always use busybox version, to ensure consistent output
+            /system/xbin/lsof | grep -F "$distro_path/"
+            echo "end of open files"
             echo
             echo "mount points under $distro_path:"
             mount | grep -F "$distro_path/"

--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -153,19 +153,22 @@ if [ "" = "$check_env" ] && [ "" = "$chrootpath" ]; then
     exit 1
 fi
 
+busyboxlsofcaller=''
 busyboxlsof=''
 if [ "" != "$busyboxpath" ] && "$busyboxpath" lsof > /dev/null 2>&1; then
     # prefer the version provided by the found busybox binary
+    busyboxlsofcaller=true
     busyboxlsof=true
     lsofpath='busybox lsof'
 elif [ -e /system/xbin/lsof ]; then
     # busybox version
     lsofpath=/system/xbin/lsof
+    busyboxlsof=true
 elif [ -e /system/bin/lsof ]; then
     # toybox version
     lsofpath=/system/bin/lsof
 else
-    # don't want to use random lsof as it may not work
+    # don't want to use random lsof as it may not work (or has different output)
     # in this case user has to manually run the command
     lsofpath=''
 fi
@@ -196,7 +199,7 @@ wget() { busybox wget "$@"; }
 chroot() { "$chrootpath" "$@"; }
 
 lsof() {
-    if [ "" != "$busyboxlsof" ]; then
+    if [ "" != "$busyboxlsofcaller" ]; then
         busybox lsof
     elif [ "" = "$lsofpath" ]; then
         # lsof is optional, no output
@@ -336,10 +339,14 @@ $script redownload <distro> - redownload rootfs
 $script delete <distro> - delete rootfs
 
 $script install <distro> [-a|--android] - install distro
-    '-a|--android' Installs also /data and /system folders, by default not installed
-$script reinstall <distro> [-a|--android] - reinstall distro
-    '-a|--android' Installs also /data and /system folders, by default not installed
-$script uninstall <distro> - uninstall distro
+    '-a|--android'  Installs also /data and /system folders, by default not installed
+$script reinstall <distro> [-a|--android] [-f|--force] - reinstall distro
+    '-a|--android'  Installs also /data and /system folders, by default not installed
+    '-f|--force'    Force closing open files (closes the process accessing them)
+                    and/or unmounting active mounts. Use with care.
+$script uninstall <distro> [-f|--force] - uninstall distro
+    '-f|--force'    Force closing open files (closes the process accessing them)
+                    and/or unmounting active mounts. Use with care.
 
 $script unmount <distro> - unmount system mount points from distro
 
@@ -863,6 +870,26 @@ chroot_distro_check_if_supported() {
     fi
 }
 
+chroot_distro_find_processes_with_open_files() {
+    path="$1"
+    if [ "" != "$busyboxlsof" ]; then
+        # busybox has own format for lsof output
+        lsof | grep -F "$path" | grep -Eo '^[[:digit:]]+' | sort -n | uniq
+    else
+        lsof | grep -F "$path" | cut -c10- | grep -Eo '^ *[[:digit:]]+' | grep -Eo '[[:digit:]]+' | sort -n | uniq
+    fi
+}
+
+chroot_distro_find_all_mount_points() {
+    path="$1"
+    mount | grep -F "$path" | grep -Eo '^[[:alnum:][:punct:]\/]+ on [[:alnum:][:punct:]\/]+' | grep -Eo '[[:alnum:][:punct:]\/]+$'
+}
+
+chroot_distro_find_all_loopback_mount_points() {
+    path="$1"
+    losetup -a | grep -F "$path" | grep -Eo '^[^:]+'
+}
+
 chroot_distro_delete() {
     supported="alpine archlinux artix debian deepin fedora manjaro openkylin opensuse pardus ubuntu void kali parrot backbox centos centos_stream"
     if ! chroot_distro_check_if_supported "$supported" "$1"; then
@@ -1196,14 +1223,32 @@ chroot_distro_uninstall() {
     fi
 
     distro_path="$chroot_distro_path/$1"
+    force=$2
+
     if [ -d "$distro_path" ]; then
+        if [ "yes" = "$force" ]; then
+            # first try to kill all processes before trying to unmount anything
+            # note: close from earlier to later processes to ensure that no new worker processes are created during killing
+            chroot_distro_find_processes_with_open_files "$distro_path/" | xargs -I {} kill {} > /dev/null 2>&1
+            # before normal unmounts, go through all loopback devices
+            # note: in reverse order in case there is loopback mount from inside the loopback mount (quite contrived case but just in case...)
+            chroot_distro_find_all_loopback_mount_points "$distro_path/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
+            # try to unmount everything found
+            # note: using reverse sort to ensure that mounts residing deeper in the file system will be unmmounted first
+            chroot_distro_find_all_mount_points "$distro_path/" | sort -r | xargs -I {} umount {} > /dev/null 2>&1
+            # then hope for the best...
+        fi
         chroot_distro_unmount_system_points "$distro_path"
         mount_count=$(mount | grep -Fc "$distro_path")
         loopback_count=$(losetup -a | grep -Fc "$distro_path")
         open_file_count=$(lsof | grep -Fc "$distro_path")
         if [ "0" != "$mount_count" ] || [ "0" != "$loopback_count" ] || [ "0" != "$open_file_count" ]; then
             # note: if there is still system mount points mounted, please create a bug report so that it can be investigated
-            echo "distro is potentially running - if needed shutdown the distro, and unmount mounted folders"
+            echo 'distro is potentially running - if needed shutdown the distro, and unmount mounted folders'
+            if [ "yes" != "$force" ]; then
+                echo 'You can try running uninstall/reinstall again with -f(--force) option to automatically close/unmount files/folders mentioned below.'
+                echo 'Please note, that using --force option may close more programs than intended, so use it with care.'
+            fi
             echo
             echo "open files under $distro_path:"
             if [ "" != "$lsofpath" ]; then
@@ -1655,10 +1700,15 @@ elif [ "$command" = "install" ]; then
     chroot_distro_warn_if_unsupported_busybox
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "uninstall" ]; then
-    PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2
+    PARSED=$(getopt --options=f --longoptions=force --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
+    force=no
     while true; do
         case "$1" in
+            -f|--force)
+                force=yes
+                shift
+                ;;
             --)
                 shift
                 break
@@ -1674,17 +1724,23 @@ elif [ "$command" = "uninstall" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
-    chroot_distro_uninstall "$1"
+    chroot_distro_uninstall "$1" "$force"
 elif [ "$command" = "reinstall" ]; then
-    PARSED=$(getopt --options=a --longoptions=android --name "$0" -- "$@") || exit 2
+    OPTS=af LONGOPTS=android,force
+    PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
     eval set -- "$PARSED"
     android=no
+    force=no
     while true; do
         case "$1" in
             -a|--android)
                 android=yes
                 shift
                 ;;
+            -f|--force)
+                force=yes
+                shift
+                ;;
             --)
                 shift
                 break
@@ -1700,7 +1756,7 @@ elif [ "$command" = "reinstall" ]; then
     elif [ $# -ne 1 ]; then
         chroot_distro_user_check_parameters
     fi
-    chroot_distro_uninstall "$1"
+    chroot_distro_uninstall "$1" "$force"
     chroot_distro_install "$1" "$android"
 elif [ "$command" = "backup" ]; then
     PARSED=$(getopt --options= --longoptions= --name "$0" -- "$@") || exit 2


### PR DESCRIPTION
Added a new options `-f|--force` to `unmount` and `uninstall` commands. With this option user can forcefully shutdown the distro.

Added a new option `-a|--all` to `unmount` command. With this option not only the system mount points are unmounted but all the others as well (both normal and loopback mount points).

Even though there is a new `force` option, users are encouraged to use it only after reviewing the ramifications (ie. what programs will be closed).