### PR TITLE
Use standard Unix path for the sh shell

### DIFF
--- a/system/bin/chroot-distro
+++ b/system/bin/chroot-distro
@@ -1,4 +1,4 @@
-#!/system/bin/sh
+#!/bin/sh
 #
 # Copyright 2025 Yasser Null
 #


### PR DESCRIPTION
Previously the script couldn't be executed because it was tring to use the `/system/bin/sh` path, which doesn't exist on most of the GNU/Linux distributions. This PR replaces it the the standard Unix path `/bin/sh`, where `/bin` is usualy a symlink to either `/system/bin` (Android) or `/usr/bin` (GNU/Linux).
See also #85